### PR TITLE
Preserve function attributes (including docs) in `#[hotpath::measure]`

### DIFF
--- a/crates/hotpath-macros/src/lib.rs
+++ b/crates/hotpath-macros/src/lib.rs
@@ -277,6 +277,9 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn measure(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
+
+    let attrs = &input.attrs;
+
     let vis = &input.vis;
     let sig = &input.sig;
     let block = &input.block;
@@ -300,6 +303,7 @@ pub fn measure(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let output = quote! {
+        #(#attrs)*
         #vis #sig {
             #wrapped
         }


### PR DESCRIPTION
This PR fixes an issue where the `#[hotpath::measure]` attribute macro would drop all user-provided attributes—including documentation comments—during macro expansion. This caused missing_docs warnings/errors on any function using the macro and also removed other attributes such as `#[inline]`, `#[allow]`, `#[cfg]`, and more.

The macro is now transparent: it preserves the user’s original attributes and documentation and only wraps the function body in instrumentation logic.

Closes #81 