### PR TITLE
chore: reduce proxy channel buffer sizes to 1 where possible (#98)

### DIFF
--- a/crates/hotpath/src/lib_on/channels/wrapper/crossbeam.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/crossbeam.rs
@@ -23,8 +23,10 @@ where
     let (inner_tx, inner_rx) = inner;
     let type_name = std::any::type_name::<T>();
 
-    let (outer_tx, to_inner_rx) = crossbeam_channel::bounded::<T>(capacity);
-    let (from_inner_tx, outer_rx) = crossbeam_channel::bounded::<T>(capacity);
+    // Proxy channels must be minimal to avoid inflating buffering.
+    // See: https://github.com/pawurb/hotpath-rs/issues/98
+    let (outer_tx, to_inner_rx) = crossbeam_channel::bounded::<T>(1);
+    let (from_inner_tx, outer_rx) = crossbeam_channel::bounded::<T>(1);
 
     let (stats_tx, _) = init_channels_state();
 

--- a/crates/hotpath/src/lib_on/channels/wrapper/ftc.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/ftc.rs
@@ -27,8 +27,8 @@ where
     let (mut inner_tx, mut inner_rx) = inner;
     let type_name = std::any::type_name::<T>();
 
-    let (outer_tx, mut to_inner_rx) = mpsc::channel::<T>(capacity);
-    let (mut from_inner_tx, outer_rx) = mpsc::channel::<T>(capacity);
+    let (outer_tx, mut to_inner_rx) = mpsc::channel::<T>(1);
+    let (mut from_inner_tx, outer_rx) = mpsc::channel::<T>(1);
 
     let (stats_tx, _) = init_channels_state();
 

--- a/crates/hotpath/src/lib_on/channels/wrapper/std.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/std.rs
@@ -23,8 +23,10 @@ where
     let (inner_tx, inner_rx) = inner;
     let type_name = std::any::type_name::<T>();
 
-    let (outer_tx, to_inner_rx) = mpsc::sync_channel::<T>(capacity);
-    let (from_inner_tx, outer_rx) = mpsc::sync_channel::<T>(capacity);
+    // Proxy channels must be minimal to avoid inflating buffering.
+    // See: https://github.com/pawurb/hotpath-rs/issues/98
+    let (outer_tx, to_inner_rx) = mpsc::sync_channel::<T>(1);
+    let (from_inner_tx, outer_rx) = mpsc::sync_channel::<T>(1);
 
     let (stats_tx, _) = init_channels_state();
 

--- a/crates/hotpath/src/lib_on/channels/wrapper/tokio.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/tokio.rs
@@ -26,8 +26,10 @@ where
     let type_name = std::any::type_name::<T>();
 
     let capacity = inner_tx.capacity();
-    let (outer_tx, mut to_inner_rx) = mpsc::channel::<T>(capacity);
-    let (from_inner_tx, outer_rx) = mpsc::channel::<T>(capacity);
+    // Proxy channels must be minimal to avoid inflating buffering.
+    // See: https://github.com/pawurb/hotpath-rs/issues/98
+    let (outer_tx, mut to_inner_rx) = mpsc::channel::<T>(1);
+    let (from_inner_tx, outer_rx) = mpsc::channel::<T>(1);
 
     let (stats_tx, _) = init_channels_state();
 


### PR DESCRIPTION
Bounded channel proxies now use capacity = 1 instead of mirroring the original capacity, preventing instrumentation from inflating buffering and altering backpressure semantics.