### PR TITLE
perf: Optimize data flow fetch

### DIFF
--- a/crates/hotpath/src/lib_on/channels.rs
+++ b/crates/hotpath/src/lib_on/channels.rs
@@ -87,9 +87,27 @@ pub(crate) struct ChannelEntry {
     pub(crate) type_name: &'static str,
     pub(crate) type_size: usize,
     pub(crate) max_queued: u64,
+    pub(crate) iter: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct ChannelEntryLogs {
     pub(crate) sent_logs: VecDeque<DataFlowLogEntry>,
     pub(crate) received_logs: VecDeque<DataFlowLogEntry>,
-    pub(crate) iter: u32,
+}
+
+impl ChannelEntryLogs {
+    fn new() -> Self {
+        Self {
+            sent_logs: VecDeque::with_capacity(*LOGS_LIMIT),
+            received_logs: VecDeque::with_capacity(*LOGS_LIMIT),
+        }
+    }
+}
+
+pub(crate) struct ChannelsInternalState {
+    pub(crate) stats: HashMap<u32, ChannelEntry>,
+    pub(crate) logs: HashMap<u32, ChannelEntryLogs>,
 }
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
@@ -156,8 +174,6 @@ impl ChannelEntry {
             type_name,
             type_size,
             max_queued: 0,
-            sent_logs: VecDeque::with_capacity(*LOGS_LIMIT),
-            received_logs: VecDeque::with_capacity(*LOGS_LIMIT),
             iter,
         }
     }
@@ -215,7 +231,7 @@ pub enum ChannelEvent {
 
 pub(crate) struct ChannelsState {
     pub(crate) event_tx: CbSender<ChannelEvent>,
-    pub(crate) stats_map: Arc<RwLock<HashMap<u32, ChannelEntry>>>,
+    pub(crate) inner: Arc<RwLock<ChannelsInternalState>>,
     pub(crate) shutdown_tx: Mutex<Option<CbSender<()>>>,
     pub(crate) completion_rx: Mutex<Option<CbReceiver<()>>>,
 }
@@ -229,7 +245,7 @@ pub(crate) use crate::lib_on::START_TIME;
 pub(crate) use crate::lib_on::hotpath_guard::LOGS_LIMIT;
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn process_channel_event(stats: &mut HashMap<u32, ChannelEntry>, event: ChannelEvent) {
+fn process_channel_event(state: &mut ChannelsInternalState, event: ChannelEvent) {
     match event {
         ChannelEvent::Created {
             id,
@@ -239,8 +255,8 @@ fn process_channel_event(stats: &mut HashMap<u32, ChannelEntry>, event: ChannelE
             type_name,
             type_size,
         } => {
-            let iter = stats.values().filter(|s| s.source == source).count() as u32;
-            stats.insert(
+            let iter = state.stats.values().filter(|s| s.source == source).count() as u32;
+            state.stats.insert(
                 id,
                 ChannelEntry::new(
                     id,
@@ -252,18 +268,21 @@ fn process_channel_event(stats: &mut HashMap<u32, ChannelEntry>, event: ChannelE
                     iter,
                 ),
             );
+            state.logs.insert(id, ChannelEntryLogs::new());
         }
         ChannelEvent::MessageSent { id, log, timestamp } => {
-            if let Some(channel_stats) = stats.get_mut(&id) {
+            if let Some(channel_stats) = state.stats.get_mut(&id) {
                 channel_stats.sent_count += 1;
                 channel_stats.update_state();
-
+            }
+            if let Some(entry_logs) = state.logs.get_mut(&id) {
+                let sent_count = state.stats.get(&id).map_or(0, |s| s.sent_count);
                 let limit = *LOGS_LIMIT;
-                if channel_stats.sent_logs.len() >= limit {
-                    channel_stats.sent_logs.pop_front();
+                if entry_logs.sent_logs.len() >= limit {
+                    entry_logs.sent_logs.pop_front();
                 }
-                channel_stats.sent_logs.push_back(DataFlowLogEntry::new(
-                    channel_stats.sent_count,
+                entry_logs.sent_logs.push_back(DataFlowLogEntry::new(
+                    sent_count,
                     timestamp_nanos(timestamp),
                     log,
                     None,
@@ -271,16 +290,18 @@ fn process_channel_event(stats: &mut HashMap<u32, ChannelEntry>, event: ChannelE
             }
         }
         ChannelEvent::MessageReceived { id, timestamp } => {
-            if let Some(channel_stats) = stats.get_mut(&id) {
+            if let Some(channel_stats) = state.stats.get_mut(&id) {
                 channel_stats.received_count += 1;
                 channel_stats.update_state();
-
+            }
+            if let Some(entry_logs) = state.logs.get_mut(&id) {
+                let received_count = state.stats.get(&id).map_or(0, |s| s.received_count);
                 let limit = *LOGS_LIMIT;
-                if channel_stats.received_logs.len() >= limit {
-                    channel_stats.received_logs.pop_front();
+                if entry_logs.received_logs.len() >= limit {
+                    entry_logs.received_logs.pop_front();
                 }
-                channel_stats.received_logs.push_back(DataFlowLogEntry::new(
-                    channel_stats.received_count,
+                entry_logs.received_logs.push_back(DataFlowLogEntry::new(
+                    received_count,
                     timestamp_nanos(timestamp),
                     None,
                     None,
@@ -288,12 +309,12 @@ fn process_channel_event(stats: &mut HashMap<u32, ChannelEntry>, event: ChannelE
             }
         }
         ChannelEvent::Closed { id } => {
-            if let Some(channel_stats) = stats.get_mut(&id) {
+            if let Some(channel_stats) = state.stats.get_mut(&id) {
                 channel_stats.state = ChannelState::Closed;
             }
         }
         ChannelEvent::Notified { id } => {
-            if let Some(channel_stats) = stats.get_mut(&id) {
+            if let Some(channel_stats) = state.stats.get_mut(&id) {
                 channel_stats.state = ChannelState::Notified;
             }
         }
@@ -324,8 +345,11 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
             label = "hp-ch-completion",
             log = true
         );
-        let stats_map = Arc::new(RwLock::new(HashMap::<u32, ChannelEntry>::new()));
-        let stats_map_clone = Arc::clone(&stats_map);
+        let inner = Arc::new(RwLock::new(ChannelsInternalState {
+            stats: HashMap::new(),
+            logs: HashMap::new(),
+        }));
+        let inner_clone = Arc::clone(&inner);
 
         std::thread::Builder::new()
             .name("hp-channels".into())
@@ -340,7 +364,7 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
                                 Ok(event) => {
                                     local_buffer.push(event);
                                     if local_buffer.len() >= WORKER_BATCH_SIZE {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_channel_event(&mut shared, e);
                                             }
@@ -349,7 +373,7 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
                                 }
                                 Err(_) => {
                                     if !local_buffer.is_empty() {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_channel_event(&mut shared, e);
                                             }
@@ -360,7 +384,7 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
                             }
                         }
                         recv(shutdown_rx) -> _ => {
-                            if let Ok(mut shared) = stats_map_clone.write() {
+                            if let Ok(mut shared) = inner_clone.write() {
                                 for e in local_buffer.drain(..) {
                                     process_channel_event(&mut shared, e);
                                 }
@@ -372,7 +396,7 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
                         }
                         default(flush_interval) => {
                             if !local_buffer.is_empty() {
-                                if let Ok(mut shared) = stats_map_clone.write() {
+                                if let Ok(mut shared) = inner_clone.write() {
                                     for e in local_buffer.drain(..) {
                                         process_channel_event(&mut shared, e);
                                     }
@@ -390,7 +414,7 @@ pub(crate) fn init_channels_state() -> &'static ChannelStatsState {
 
         ChannelsState {
             event_tx,
-            stats_map,
+            inner,
             shutdown_tx: Mutex::new(Some(shutdown_tx)),
             completion_rx: Mutex::new(Some(completion_rx)),
         }
@@ -627,15 +651,6 @@ macro_rules! channel {
     }};
 }
 
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn get_all_channel_stats() -> HashMap<u32, ChannelEntry> {
-    if let Some(state) = CHANNELS_STATE.get() {
-        state.stats_map.read().unwrap().clone()
-    } else {
-        HashMap::new()
-    }
-}
-
 /// Compare two channel stats for sorting.
 /// Custom labels come first (sorted alphabetically), then auto-generated labels (sorted by source and iter).
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
@@ -658,7 +673,11 @@ pub(crate) fn compare_channel_entries(a: &ChannelEntry, b: &ChannelEntry) -> std
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
 pub(crate) fn get_sorted_channel_entries() -> Vec<ChannelEntry> {
-    let mut stats: Vec<ChannelEntry> = get_all_channel_stats().into_values().collect();
+    let Some(state) = CHANNELS_STATE.get() else {
+        return Vec::new();
+    };
+    let guard = state.inner.read().unwrap();
+    let mut stats: Vec<ChannelEntry> = guard.stats.values().cloned().collect();
     stats.sort_by(compare_channel_entries);
     stats
 }
@@ -667,10 +686,11 @@ pub(crate) fn get_sorted_channel_entries() -> Vec<ChannelEntry> {
 pub(crate) fn get_channel_logs(channel_id: &str) -> Option<ChannelLogs> {
     let id = channel_id.parse::<u32>().ok()?;
     let state = CHANNELS_STATE.get()?;
-    let channels_data = state.stats_map.read().unwrap();
-    channels_data.get(&id).map(|channel_stats| ChannelLogs {
+    let guard = state.inner.read().unwrap();
+    let entry_logs = guard.logs.get(&id)?;
+    Some(ChannelLogs {
         id: channel_id.to_string(),
-        sent_logs: channel_stats.sent_logs.iter().rev().cloned().collect(),
-        received_logs: channel_stats.received_logs.iter().rev().cloned().collect(),
+        sent_logs: entry_logs.sent_logs.iter().rev().cloned().collect(),
+        received_logs: entry_logs.received_logs.iter().rev().cloned().collect(),
     })
 }

--- a/crates/hotpath/src/lib_on/futures.rs
+++ b/crates/hotpath/src/lib_on/futures.rs
@@ -61,7 +61,6 @@ pub struct FutureEntry {
     pub id: u32,
     pub source: &'static str,
     pub label: Option<String>,
-    pub logs: VecDeque<FutureLog>,
     pub logs_count: u64,
     pub total_poll_count: u64,
     pub total_poll_duration_ns: u64,
@@ -74,7 +73,6 @@ impl FutureEntry {
             id,
             source,
             label,
-            logs: VecDeque::with_capacity(*LOGS_LIMIT),
             logs_count: 0,
             total_poll_count: 0,
             total_poll_duration_ns: 0,
@@ -88,11 +86,28 @@ impl FutureEntry {
     pub fn total_poll_duration_ns(&self) -> u64 {
         self.total_poll_duration_ns
     }
+}
 
-    /// Find a call by ID
+#[derive(Debug)]
+pub(crate) struct FutureEntryLogs {
+    pub(crate) logs: VecDeque<FutureLog>,
+}
+
+impl FutureEntryLogs {
+    fn new() -> Self {
+        Self {
+            logs: VecDeque::with_capacity(*LOGS_LIMIT),
+        }
+    }
+
     fn find_call_mut(&mut self, id: u32) -> Option<&mut FutureLog> {
         self.logs.iter_mut().find(|c| c.id == id)
     }
+}
+
+pub(crate) struct FuturesInternalState {
+    pub(crate) stats: HashMap<u32, FutureEntry>,
+    pub(crate) logs: HashMap<u32, FutureEntryLogs>,
 }
 
 impl From<&FutureEntry> for JsonFutureEntry {
@@ -149,7 +164,7 @@ pub(crate) enum FutureEvent {
 
 pub(crate) struct FuturesState {
     pub(crate) event_tx: CbSender<FutureEvent>,
-    pub(crate) stats_map: Arc<RwLock<HashMap<u32, FutureEntry>>>,
+    pub(crate) inner: Arc<RwLock<FuturesInternalState>>,
     pub(crate) shutdown_tx: Mutex<Option<CbSender<()>>>,
     pub(crate) completion_rx: Mutex<Option<CbReceiver<()>>>,
 }
@@ -185,8 +200,11 @@ pub fn init_futures_state() {
             label = "hp-ft-completion",
             log = true
         );
-        let stats_map = Arc::new(RwLock::new(HashMap::<u32, FutureEntry>::new()));
-        let stats_map_clone = Arc::clone(&stats_map);
+        let inner = Arc::new(RwLock::new(FuturesInternalState {
+            stats: HashMap::new(),
+            logs: HashMap::new(),
+        }));
+        let inner_clone = Arc::clone(&inner);
 
         std::thread::Builder::new()
             .name("hp-futures".into())
@@ -201,7 +219,7 @@ pub fn init_futures_state() {
                                 Ok(event) => {
                                     local_buffer.push(event);
                                     if local_buffer.len() >= WORKER_BATCH_SIZE {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_future_event(&mut shared, e);
                                             }
@@ -210,7 +228,7 @@ pub fn init_futures_state() {
                                 }
                                 Err(_) => {
                                     if !local_buffer.is_empty() {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_future_event(&mut shared, e);
                                             }
@@ -221,7 +239,7 @@ pub fn init_futures_state() {
                             }
                         }
                         recv(shutdown_rx) -> _ => {
-                            if let Ok(mut shared) = stats_map_clone.write() {
+                            if let Ok(mut shared) = inner_clone.write() {
                                 for e in local_buffer.drain(..) {
                                     process_future_event(&mut shared, e);
                                 }
@@ -233,7 +251,7 @@ pub fn init_futures_state() {
                         }
                         default(flush_interval) => {
                             if !local_buffer.is_empty() {
-                                if let Ok(mut shared) = stats_map_clone.write() {
+                                if let Ok(mut shared) = inner_clone.write() {
                                     for e in local_buffer.drain(..) {
                                         process_future_event(&mut shared, e);
                                     }
@@ -249,7 +267,7 @@ pub fn init_futures_state() {
 
         FuturesState {
             event_tx,
-            stats_map,
+            inner,
             shutdown_tx: Mutex::new(Some(shutdown_tx)),
             completion_rx: Mutex::new(Some(completion_rx)),
         }
@@ -258,26 +276,29 @@ pub fn init_futures_state() {
 
 /// Process a future event and update stats.
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn process_future_event(stats_map: &mut HashMap<u32, FutureEntry>, event: FutureEvent) {
+fn process_future_event(state: &mut FuturesInternalState, event: FutureEvent) {
     match event {
         FutureEvent::Created {
             future_id,
             source,
             display_label,
         } => {
-            stats_map.insert(
+            state.stats.insert(
                 future_id,
                 FutureEntry::new(future_id, source, display_label),
             );
+            state.logs.insert(future_id, FutureEntryLogs::new());
         }
         FutureEvent::CallCreated { future_id, call_id } => {
-            if let Some(future_stats) = stats_map.get_mut(&future_id) {
+            if let Some(future_stats) = state.stats.get_mut(&future_id) {
                 future_stats.logs_count += 1;
+            }
+            if let Some(entry_logs) = state.logs.get_mut(&future_id) {
                 let limit = *LOGS_LIMIT;
-                if future_stats.logs.len() >= limit {
-                    future_stats.logs.pop_front();
+                if entry_logs.logs.len() >= limit {
+                    entry_logs.logs.pop_front();
                 }
-                future_stats
+                entry_logs
                     .logs
                     .push_back(FutureLog::new(call_id, future_id));
             }
@@ -289,10 +310,12 @@ fn process_future_event(stats_map: &mut HashMap<u32, FutureEntry>, event: Future
             log_message,
             poll_duration_ns,
         } => {
-            if let Some(future_stats) = stats_map.get_mut(&future_id) {
+            if let Some(future_stats) = state.stats.get_mut(&future_id) {
                 future_stats.total_poll_count += 1;
                 future_stats.total_poll_duration_ns += poll_duration_ns;
-                if let Some(call) = future_stats.find_call_mut(call_id) {
+            }
+            if let Some(entry_logs) = state.logs.get_mut(&future_id) {
+                if let Some(call) = entry_logs.find_call_mut(call_id) {
                     call.poll_count += 1;
                     call.total_poll_duration_ns += poll_duration_ns;
                     call.last_poll_duration_ns = poll_duration_ns;
@@ -314,15 +337,15 @@ fn process_future_event(stats_map: &mut HashMap<u32, FutureEntry>, event: Future
             }
         }
         FutureEvent::Completed { future_id, call_id } => {
-            if let Some(future_stats) = stats_map.get_mut(&future_id) {
-                if let Some(call) = future_stats.find_call_mut(call_id) {
+            if let Some(entry_logs) = state.logs.get_mut(&future_id) {
+                if let Some(call) = entry_logs.find_call_mut(call_id) {
                     call.state = FutureState::Ready;
                 }
             }
         }
         FutureEvent::Cancelled { future_id, call_id } => {
-            if let Some(future_stats) = stats_map.get_mut(&future_id) {
-                if let Some(call) = future_stats.find_call_mut(call_id) {
+            if let Some(entry_logs) = state.logs.get_mut(&future_id) {
+                if let Some(call) = entry_logs.find_call_mut(call_id) {
                     if call.state != FutureState::Ready {
                         call.state = FutureState::Cancelled;
                     }
@@ -393,17 +416,12 @@ pub(crate) fn compare_future_stats(a: &FutureEntry, b: &FutureEntry) -> std::cmp
 }
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn get_all_future_stats() -> HashMap<u32, FutureEntry> {
-    if let Some(state) = FUTURES_STATE.get() {
-        state.stats_map.read().unwrap().clone()
-    } else {
-        HashMap::new()
-    }
-}
-
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
 pub(crate) fn get_sorted_future_stats() -> Vec<FutureEntry> {
-    let mut stats: Vec<FutureEntry> = get_all_future_stats().into_values().collect();
+    let Some(state) = FUTURES_STATE.get() else {
+        return Vec::new();
+    };
+    let guard = state.inner.read().unwrap();
+    let mut stats: Vec<FutureEntry> = guard.stats.values().cloned().collect();
     stats.sort_by(compare_future_stats);
     stats
 }
@@ -411,13 +429,15 @@ pub(crate) fn get_sorted_future_stats() -> Vec<FutureEntry> {
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
 pub(crate) fn get_future_logs_list(future_id: u32) -> Option<FutureLogsList> {
     let state = FUTURES_STATE.get()?;
-    let futures_data = state.stats_map.read().unwrap();
-    futures_data.get(&future_id).map(|s| FutureLogsList {
+    let guard = state.inner.read().unwrap();
+    let stats = guard.stats.get(&future_id)?;
+    let entry_logs = guard.logs.get(&future_id)?;
+    Some(FutureLogsList {
         id: future_id.to_string(),
-        call_count: s.logs_count,
-        total_polls: s.total_polls(),
-        total_poll_duration_ns: s.total_poll_duration_ns(),
-        calls: s.logs.iter().rev().cloned().collect(),
+        call_count: stats.logs_count,
+        total_polls: stats.total_polls(),
+        total_poll_duration_ns: stats.total_poll_duration_ns(),
+        calls: entry_logs.logs.iter().rev().cloned().collect(),
     })
 }
 

--- a/crates/hotpath/src/lib_on/report.rs
+++ b/crates/hotpath/src/lib_on/report.rs
@@ -45,10 +45,13 @@ pub(crate) fn shutdown_channels() -> Vec<ChannelEntry> {
                 .ok()
                 .and_then(|mut guard| guard.take())
                 .and_then(|rx| rx.recv().ok());
-            state.stats_map.read().ok().map(|stats| stats.clone())
+            state
+                .inner
+                .read()
+                .ok()
+                .map(|inner| inner.stats.values().cloned().collect::<Vec<_>>())
         })
-        .map(|stats| {
-            let mut channels: Vec<ChannelEntry> = stats.into_values().collect();
+        .map(|mut channels| {
             channels.sort_by(compare_channel_entries);
             channels
         })
@@ -133,10 +136,13 @@ pub(crate) fn shutdown_streams() -> Vec<StreamStats> {
                 .ok()
                 .and_then(|mut guard| guard.take())
                 .and_then(|rx| rx.recv().ok());
-            state.stats_map.read().ok().map(|stats| stats.clone())
+            state
+                .inner
+                .read()
+                .ok()
+                .map(|inner| inner.stats.values().cloned().collect::<Vec<_>>())
         })
-        .map(|stats| {
-            let mut streams: Vec<StreamStats> = stats.into_values().collect();
+        .map(|mut streams| {
             streams.sort_by(compare_stream_stats);
             streams
         })
@@ -207,10 +213,13 @@ pub(crate) fn shutdown_futures() -> Vec<FutureEntry> {
                 .ok()
                 .and_then(|mut guard| guard.take())
                 .and_then(|rx| rx.recv().ok());
-            state.stats_map.read().ok().map(|stats| stats.clone())
+            state
+                .inner
+                .read()
+                .ok()
+                .map(|inner| inner.stats.values().cloned().collect::<Vec<_>>())
         })
-        .map(|stats| {
-            let mut futures: Vec<FutureEntry> = stats.into_values().collect();
+        .map(|mut futures| {
             futures.sort_by(compare_future_stats);
             futures
         })

--- a/crates/hotpath/src/lib_on/streams.rs
+++ b/crates/hotpath/src/lib_on/streams.rs
@@ -29,7 +29,6 @@ pub(crate) struct StreamStats {
     pub(crate) items_yielded: u64,
     pub(crate) type_name: &'static str,
     pub(crate) type_size: usize,
-    pub(crate) logs: VecDeque<DataFlowLogEntry>,
     pub(crate) iter: u32,
 }
 
@@ -51,10 +50,27 @@ impl StreamStats {
             items_yielded: 0,
             type_name,
             type_size,
-            logs: VecDeque::with_capacity(*LOGS_LIMIT),
             iter,
         }
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct StreamStatsLogs {
+    pub(crate) logs: VecDeque<DataFlowLogEntry>,
+}
+
+impl StreamStatsLogs {
+    fn new() -> Self {
+        Self {
+            logs: VecDeque::with_capacity(*LOGS_LIMIT),
+        }
+    }
+}
+
+pub(crate) struct StreamsInternalState {
+    pub(crate) stats: HashMap<u32, StreamStats>,
+    pub(crate) logs: HashMap<u32, StreamStatsLogs>,
 }
 
 impl From<&StreamStats> for JsonStreamEntry {
@@ -97,7 +113,7 @@ pub(crate) enum StreamEvent {
 
 pub(crate) struct StreamsState {
     pub(crate) event_tx: CbSender<StreamEvent>,
-    pub(crate) stats_map: Arc<RwLock<HashMap<u32, StreamStats>>>,
+    pub(crate) inner: Arc<RwLock<StreamsInternalState>>,
     pub(crate) shutdown_tx: Mutex<Option<CbSender<()>>>,
     pub(crate) completion_rx: Mutex<Option<CbReceiver<()>>>,
 }
@@ -107,7 +123,7 @@ pub(crate) type StreamStatsState = StreamsState;
 pub(crate) static STREAMS_STATE: OnceLock<StreamStatsState> = OnceLock::new();
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn process_stream_event(stats: &mut HashMap<u32, StreamStats>, event: StreamEvent) {
+fn process_stream_event(state: &mut StreamsInternalState, event: StreamEvent) {
     match event {
         StreamEvent::Created {
             id,
@@ -116,22 +132,25 @@ fn process_stream_event(stats: &mut HashMap<u32, StreamStats>, event: StreamEven
             type_name,
             type_size,
         } => {
-            let iter = stats.values().filter(|s| s.source == source).count() as u32;
-            stats.insert(
+            let iter = state.stats.values().filter(|s| s.source == source).count() as u32;
+            state.stats.insert(
                 id,
                 StreamStats::new(id, source, display_label, type_name, type_size, iter),
             );
+            state.logs.insert(id, StreamStatsLogs::new());
         }
         StreamEvent::Yielded { id, log, timestamp } => {
-            if let Some(stream_stats) = stats.get_mut(&id) {
+            if let Some(stream_stats) = state.stats.get_mut(&id) {
                 stream_stats.items_yielded += 1;
-
+            }
+            if let Some(entry_logs) = state.logs.get_mut(&id) {
+                let items_yielded = state.stats.get(&id).map_or(0, |s| s.items_yielded);
                 let limit = *crate::channels::LOGS_LIMIT;
-                if stream_stats.logs.len() >= limit {
-                    stream_stats.logs.pop_front();
+                if entry_logs.logs.len() >= limit {
+                    entry_logs.logs.pop_front();
                 }
-                stream_stats.logs.push_back(DataFlowLogEntry::new(
-                    stream_stats.items_yielded,
+                entry_logs.logs.push_back(DataFlowLogEntry::new(
+                    items_yielded,
                     crate::channels::timestamp_nanos(timestamp),
                     log,
                     None,
@@ -139,7 +158,7 @@ fn process_stream_event(stats: &mut HashMap<u32, StreamStats>, event: StreamEven
             }
         }
         StreamEvent::Completed { id } => {
-            if let Some(stream_stats) = stats.get_mut(&id) {
+            if let Some(stream_stats) = state.stats.get_mut(&id) {
                 stream_stats.state = ChannelState::Closed;
             }
         }
@@ -171,8 +190,11 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
             label = "hp-st-completion",
             log = true
         );
-        let stats_map = Arc::new(RwLock::new(HashMap::<u32, StreamStats>::new()));
-        let stats_map_clone = Arc::clone(&stats_map);
+        let inner = Arc::new(RwLock::new(StreamsInternalState {
+            stats: HashMap::new(),
+            logs: HashMap::new(),
+        }));
+        let inner_clone = Arc::clone(&inner);
 
         std::thread::Builder::new()
             .name("hp-streams".into())
@@ -187,7 +209,7 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
                                 Ok(event) => {
                                     local_buffer.push(event);
                                     if local_buffer.len() >= WORKER_BATCH_SIZE {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_stream_event(&mut shared, e);
                                             }
@@ -196,7 +218,7 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
                                 }
                                 Err(_) => {
                                     if !local_buffer.is_empty() {
-                                        if let Ok(mut shared) = stats_map_clone.write() {
+                                        if let Ok(mut shared) = inner_clone.write() {
                                             for e in local_buffer.drain(..) {
                                                 process_stream_event(&mut shared, e);
                                             }
@@ -207,7 +229,7 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
                             }
                         }
                         recv(shutdown_rx) -> _ => {
-                            if let Ok(mut shared) = stats_map_clone.write() {
+                            if let Ok(mut shared) = inner_clone.write() {
                                 for e in local_buffer.drain(..) {
                                     process_stream_event(&mut shared, e);
                                 }
@@ -219,7 +241,7 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
                         }
                         default(flush_interval) => {
                             if !local_buffer.is_empty() {
-                                if let Ok(mut shared) = stats_map_clone.write() {
+                                if let Ok(mut shared) = inner_clone.write() {
                                     for e in local_buffer.drain(..) {
                                         process_stream_event(&mut shared, e);
                                     }
@@ -237,7 +259,7 @@ pub(crate) fn init_streams_state() -> &'static StreamStatsState {
 
         StreamsState {
             event_tx,
-            stats_map,
+            inner,
             shutdown_tx: Mutex::new(Some(shutdown_tx)),
             completion_rx: Mutex::new(Some(completion_rx)),
         }
@@ -345,15 +367,6 @@ macro_rules! stream {
     }};
 }
 
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-fn get_all_stream_stats() -> HashMap<u32, StreamStats> {
-    if let Some(state) = STREAMS_STATE.get() {
-        state.stats_map.read().unwrap().clone()
-    } else {
-        HashMap::new()
-    }
-}
-
 /// Compare two stream stats for sorting.
 /// Custom labels come first (sorted alphabetically), then auto-generated labels (sorted by source and iter).
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
@@ -376,7 +389,11 @@ pub(crate) fn compare_stream_stats(a: &StreamStats, b: &StreamStats) -> std::cmp
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
 pub(crate) fn get_sorted_stream_stats() -> Vec<StreamStats> {
-    let mut stats: Vec<StreamStats> = get_all_stream_stats().into_values().collect();
+    let Some(state) = STREAMS_STATE.get() else {
+        return Vec::new();
+    };
+    let guard = state.inner.read().unwrap();
+    let mut stats: Vec<StreamStats> = guard.stats.values().cloned().collect();
     stats.sort_by(compare_stream_stats);
     stats
 }
@@ -385,16 +402,12 @@ pub(crate) fn get_sorted_stream_stats() -> Vec<StreamStats> {
 pub(crate) fn get_stream_logs(stream_id: &str) -> Option<StreamLogs> {
     let id = stream_id.parse::<u32>().ok()?;
     let state = STREAMS_STATE.get()?;
-    let streams_data = state.stats_map.read().unwrap();
-    streams_data.get(&id).map(|stream_stats| {
-        let mut yielded_logs: Vec<DataFlowLogEntry> = stream_stats.logs.iter().cloned().collect();
-
-        // Sort by index descending (most recent first)
-        yielded_logs.sort_by(|a, b| b.index.cmp(&a.index));
-
-        StreamLogs {
-            id: stream_id.to_string(),
-            logs: yielded_logs,
-        }
+    let guard = state.inner.read().unwrap();
+    let entry_logs = guard.logs.get(&id)?;
+    let mut yielded_logs: Vec<DataFlowLogEntry> = entry_logs.logs.iter().cloned().collect();
+    yielded_logs.sort_by(|a, b| b.index.cmp(&a.index));
+    Some(StreamLogs {
+        id: stream_id.to_string(),
+        logs: yielded_logs,
     })
 }


### PR DESCRIPTION
 ## Timing wins

  | Function | Avg | Total |
  |---|---|---|
  | `data_flow::get_data_flow_json` | -87.9% | -87.7% |
  | `channels::get_sorted_channel_entries` | -91.5% | -91.3% |
  | `metrics_server::handle_request` | -66.5% | -66.2% |
  | `metrics_server::respond_json` | -9.0% | -8.3% |

  ## Allocation wins

  | Function | Avg | Total |
  |---|---|---|
  | `futures::get_sorted_future_stats` | -98.6% | -98.7% |
  | `channels::get_sorted_channel_entries` | -95.9% | -95.9% |
  | `data_flow::get_data_flow_json` | -91.8% | -91.7% |
  | `metrics_server::handle_request` | -82.1% | -82.0% |