### PR TITLE
feat!: Add runtime aware async alloc metrics

### DIFF
--- a/crates/hotpath-macros/src/lib_on.rs
+++ b/crates/hotpath-macros/src/lib_on.rs
@@ -373,13 +373,10 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             {
                 const FUTURE_LOC: &'static str = concat!(module_path!(), "::", stringify!(#fn_name));
-                hotpath::futures::init_futures_state();
-                hotpath::InstrumentFutureLog::instrument_future_log(
-                    async {
-                        hotpath::functions::measure_with_log_async(#loc, || async #block).await
-                    },
+                hotpath::functions::measure_with_future_log_async(
+                    #loc,
                     FUTURE_LOC,
-                    None
+                    async #block
                 ).await
             }
         }
@@ -387,18 +384,10 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             {
                 const FUTURE_LOC: &'static str = concat!(module_path!(), "::", stringify!(#fn_name));
-                hotpath::futures::init_futures_state();
-                hotpath::InstrumentFuture::instrument_future(
-                    async {
-                        let _guard = hotpath::functions::MeasurementGuard::build(
-                            concat!(module_path!(), "::", #name),
-                            false,
-                            true,
-                        );
-                        #block
-                    },
+                hotpath::functions::measure_with_future_async(
+                    concat!(module_path!(), "::", #name),
                     FUTURE_LOC,
-                    None
+                    async #block
                 ).await
             }
         }
@@ -413,20 +402,20 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 hotpath::functions::measure_with_log(#loc, false, || #block)
             }
         }
+    } else if asyncness {
+        quote! {
+            hotpath::functions::measure_async(
+                concat!(module_path!(), "::", #name),
+                async #block
+            ).await
+        }
     } else {
-        let guard_init = quote! {
-            let _guard = hotpath::functions::MeasurementGuard::build(
+        quote! {
+            let _guard = hotpath::functions::build_measurement_guard_sync(
                 concat!(module_path!(), "::", #name),
                 false,
-                #asyncness,
             );
             #block
-        };
-
-        if asyncness {
-            quote! { async { #guard_init }.await }
-        } else {
-            guard_init
         }
     };
 

--- a/crates/hotpath/bin/hotpath/cmd/console/views/data_flow/inspect.rs
+++ b/crates/hotpath/bin/hotpath/cmd/console/views/data_flow/inspect.rs
@@ -1,5 +1,5 @@
 use crate::cmd::console::app::InspectedDataFlowLog;
-use hotpath::json::format_delay;
+use hotpath::format_bytes;
 use ratatui::{
     layout::Rect,
     symbols::border,
@@ -68,20 +68,13 @@ pub(crate) fn render_inspect_popup(
             (title, message.to_string())
         }
         InspectedDataFlowLog::FutureCall(call) => {
-            let avg_poll = if call.poll_count > 0 {
-                format_delay(call.total_poll_duration_ns / call.poll_count)
-            } else {
-                "-".to_string()
-            };
-            let max_poll = if call.max_poll_duration_ns > 0 {
-                format_delay(call.max_poll_duration_ns)
-            } else {
-                "-".to_string()
-            };
-            let total_poll = format_delay(call.total_poll_duration_ns);
+            let total_alloc = call
+                .total_poll_alloc_bytes
+                .map(format_bytes)
+                .unwrap_or_else(|| "-".to_string());
             let title = format!(
-                " Result (Call ID: {}, State: {}, Polls: {}, Total: {}, Avg: {}, Max: {}) ",
-                call.id, call.state, call.poll_count, total_poll, avg_poll, max_poll
+                " Result (Call ID: {}, State: {}, Alloc: {}) ",
+                call.id, call.state, total_alloc
             );
             let message = call.result.as_deref().unwrap_or("(no result available)");
             (title, message.to_string())

--- a/crates/hotpath/bin/hotpath/cmd/console/views/data_flow/logs.rs
+++ b/crates/hotpath/bin/hotpath/cmd/console/views/data_flow/logs.rs
@@ -1,7 +1,7 @@
 use crate::cmd::console::app::DataFlowLogs;
 use crate::cmd::console::views::common_styles;
 use crate::cmd::console::widgets::formatters::truncate_message;
-use hotpath::json::{format_delay, DataFlowType};
+use hotpath::{format_bytes, json::DataFlowType};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Color, Style},
@@ -144,29 +144,30 @@ pub(crate) fn render_logs_panel(
             frame.render_stateful_widget(table, inner_area, table_state);
         }
         (DataFlowLogs::Future(future_logs), DataFlowType::Future) => {
-            let total_polls = future_logs.total_polls;
-            let total_ns = future_logs.total_poll_duration_ns;
-            let avg = if total_polls > 0 {
-                format_delay(total_ns / total_polls)
-            } else {
-                "-".to_string()
-            };
-            let summary = format!(
-                " calls: {} | polls: {} | total: {} | avg: {}",
-                future_logs.call_count,
-                total_polls,
-                format_delay(total_ns),
-                avg,
+            let total_alloc_bytes = future_logs.total_poll_alloc_bytes;
+            let total_alloc_count = future_logs.total_poll_alloc_count;
+            let mut summary = format!(
+                " calls: {} | polls: {}",
+                future_logs.call_count, future_logs.total_polls,
             );
+            if let Some(total_alloc_bytes) = total_alloc_bytes {
+                summary.push_str(&format!(
+                    " | alloc total: {}",
+                    format_bytes(total_alloc_bytes)
+                ));
+            }
+            if let Some(total_alloc_count) = total_alloc_count {
+                summary.push_str(&format!(" | alloc count: {}", total_alloc_count));
+            }
 
             let [summary_area, table_area] =
                 Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(inner_area);
 
             frame.render_widget(Paragraph::new(Line::raw(summary)), summary_area);
 
-            let result_width = (available_width.saturating_sub(41) as usize).max(10);
+            let result_width = (available_width.saturating_sub(33) as usize).max(10);
 
-            let header = Row::new(vec!["State", "Polls", "Avg Poll", "Max Poll", "Result"])
+            let header = Row::new(vec!["State", "Polls", "Alloc", "Result"])
                 .style(common_styles::HEADER_STYLE_CYAN)
                 .height(1);
 
@@ -176,33 +177,24 @@ pub(crate) fn render_logs_panel(
                 .map(|call| {
                     let result = call.result.as_deref().unwrap_or("-");
                     let result_text = truncate_message(result, result_width);
-
-                    let avg_poll = if call.poll_count > 0 {
-                        format_delay(call.total_poll_duration_ns / call.poll_count)
-                    } else {
-                        "-".to_string()
-                    };
-                    let max_poll = if call.max_poll_duration_ns > 0 {
-                        format_delay(call.max_poll_duration_ns)
-                    } else {
-                        "-".to_string()
-                    };
+                    let alloc = call
+                        .total_poll_alloc_bytes
+                        .map(format_bytes)
+                        .unwrap_or_else(|| "-".to_string());
 
                     Row::new(vec![
                         Cell::from(call.state.clone()).style(state_style(&call.state)),
                         Cell::from(call.poll_count.to_string()),
-                        Cell::from(avg_poll),
-                        Cell::from(max_poll),
+                        Cell::from(alloc),
                         Cell::from(result_text),
                     ])
                 })
                 .collect();
 
-            let widths = [
+            let widths = vec![
                 Constraint::Length(9),  // State
                 Constraint::Length(6),  // Polls
-                Constraint::Length(10), // Avg Poll
-                Constraint::Length(10), // Max Poll
+                Constraint::Length(12), // Alloc
                 Constraint::Min(10),    // Result
             ];
 

--- a/crates/hotpath/src/json.rs
+++ b/crates/hotpath/src/json.rs
@@ -157,6 +157,10 @@ pub(crate) struct FutureLog {
     pub total_poll_duration_ns: u64,
     pub max_poll_duration_ns: u64,
     pub last_poll_duration_ns: u64,
+    pub total_poll_alloc_bytes: Option<u64>,
+    pub total_poll_alloc_count: Option<u64>,
+    pub max_poll_alloc_bytes: Option<u64>,
+    pub last_poll_alloc_bytes: Option<u64>,
     pub result: Option<String>,
 }
 
@@ -170,6 +174,10 @@ impl FutureLog {
             total_poll_duration_ns: 0,
             max_poll_duration_ns: 0,
             last_poll_duration_ns: 0,
+            total_poll_alloc_bytes: None,
+            total_poll_alloc_count: None,
+            max_poll_alloc_bytes: None,
+            last_poll_alloc_bytes: None,
             result: None,
         }
     }
@@ -182,6 +190,8 @@ pub(crate) struct FutureLogsList {
     pub call_count: u64,
     pub total_polls: u64,
     pub total_poll_duration_ns: u64,
+    pub total_poll_alloc_bytes: Option<u64>,
+    pub total_poll_alloc_count: Option<u64>,
     pub calls: Vec<FutureLog>,
 }
 

--- a/crates/hotpath/src/json/formatted.rs
+++ b/crates/hotpath/src/json/formatted.rs
@@ -395,6 +395,8 @@ pub struct JsonFutureEntry {
     pub call_count: u64,
     pub total_polls: u64,
     pub total_poll_duration_ns: u64,
+    pub total_poll_alloc_bytes: Option<u64>,
+    pub total_poll_alloc_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -406,6 +408,10 @@ pub struct JsonFutureLog {
     pub total_poll_duration_ns: u64,
     pub max_poll_duration_ns: u64,
     pub last_poll_duration_ns: u64,
+    pub total_poll_alloc_bytes: Option<u64>,
+    pub total_poll_alloc_count: Option<u64>,
+    pub max_poll_alloc_bytes: Option<u64>,
+    pub last_poll_alloc_bytes: Option<u64>,
     pub result: Option<String>,
 }
 
@@ -472,6 +478,8 @@ pub struct JsonFutureLogsList {
     pub call_count: u64,
     pub total_polls: u64,
     pub total_poll_duration_ns: u64,
+    pub total_poll_alloc_bytes: Option<u64>,
+    pub total_poll_alloc_count: Option<u64>,
     pub calls: Vec<JsonFutureLog>,
 }
 
@@ -485,6 +493,10 @@ impl From<&FutureLog> for JsonFutureLog {
             total_poll_duration_ns: log.total_poll_duration_ns,
             max_poll_duration_ns: log.max_poll_duration_ns,
             last_poll_duration_ns: log.last_poll_duration_ns,
+            total_poll_alloc_bytes: log.total_poll_alloc_bytes,
+            total_poll_alloc_count: log.total_poll_alloc_count,
+            max_poll_alloc_bytes: log.max_poll_alloc_bytes,
+            last_poll_alloc_bytes: log.last_poll_alloc_bytes,
             result: log.result.clone(),
         }
     }
@@ -497,6 +509,8 @@ impl From<&FutureLogsList> for JsonFutureLogsList {
             call_count: calls.call_count,
             total_polls: calls.total_polls,
             total_poll_duration_ns: calls.total_poll_duration_ns,
+            total_poll_alloc_bytes: calls.total_poll_alloc_bytes,
+            total_poll_alloc_count: calls.total_poll_alloc_count,
             calls: calls.calls.iter().map(JsonFutureLog::from).collect(),
         }
     }

--- a/crates/hotpath/src/lib_off.rs
+++ b/crates/hotpath/src/lib_off.rs
@@ -163,29 +163,13 @@ pub use crate::Section;
 pub struct MeasurementGuard {}
 
 impl MeasurementGuard {
-    pub fn new(_name: &'static str, _wrapper: bool, _is_async: bool) -> Self {
+    pub fn new(_name: &'static str, _wrapper: bool) -> Self {
         Self {}
     }
 
-    pub fn build(_name: &'static str, _wrapper: bool, _is_async: bool) -> Self {
+    pub fn build(_name: &'static str, _wrapper: bool) -> Self {
         Self {}
     }
-}
-
-#[allow(dead_code)]
-pub(crate) struct MeasurementGuardWithLog {}
-
-#[allow(dead_code)]
-impl MeasurementGuardWithLog {
-    pub fn new(_name: &'static str, _wrapper: bool, _is_async: bool) -> Self {
-        Self {}
-    }
-
-    pub fn build(_name: &'static str, _wrapper: bool, _is_async: bool) -> Self {
-        Self {}
-    }
-
-    pub fn finish_with_result<T: std::fmt::Debug>(self, _result: &T) {}
 }
 
 #[inline]
@@ -272,10 +256,6 @@ impl HotpathGuardBuilder {
 
     pub fn build_with_shutdown(self, _duration: std::time::Duration) {}
 }
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub(crate) struct FunctionStats {}
 
 pub mod channels {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/hotpath/src/lib_on.rs
+++ b/crates/hotpath/src/lib_on.rs
@@ -32,7 +32,9 @@ pub use streams::{InstrumentStream, InstrumentStreamLog};
 pub mod hotpath_guard;
 pub(crate) mod report;
 
-pub use functions::{measure_with_log, measure_with_log_async, MeasurementGuard};
+pub use functions::{
+    measure_with_log, measure_with_log_async, MeasurementGuardAsync, MeasurementGuardSync,
+};
 pub use hotpath_guard::{HotpathGuard, HotpathGuardBuilder};
 
 cfg_if::cfg_if! {
@@ -79,7 +81,7 @@ cfg_if::cfg_if! {
 #[macro_export]
 macro_rules! measure_block {
     ($label:expr, $expr:expr) => {{
-        let _guard = hotpath::functions::MeasurementGuard::build($label, false, false);
+        let _guard = hotpath::functions::build_measurement_guard_sync($label, false);
 
         $expr
     }};

--- a/crates/hotpath/src/lib_on/functions.rs
+++ b/crates/hotpath/src/lib_on/functions.rs
@@ -1,5 +1,6 @@
 //! Function profiling module - measures execution time and memory allocations per function.
 
+use std::future::Future;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{sync::LazyLock, sync::OnceLock, sync::RwLock, time::Duration};
 
@@ -13,15 +14,24 @@ use crate::output::FunctionLogsList;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "hotpath-alloc")] {
-        pub mod alloc;
+        pub(crate) mod alloc;
         use alloc::state::FunctionsState;
-        pub use alloc::guard::MeasurementGuard;
-        pub(crate) use alloc::guard::MeasurementGuardWithLog;
+        pub(crate) use alloc::guard::AsyncAllocBridge;
+        pub use alloc::guard::{MeasurementGuardAsync, MeasurementGuardSync};
+        pub(crate) use alloc::guard::{MeasurementGuardAsyncWithLog, MeasurementGuardSyncWithLog};
     } else {
-        pub mod timing;
+        pub(crate) mod timing;
         use timing::state::FunctionsState;
-        pub use timing::guard::MeasurementGuard;
-        pub(crate) use timing::guard::MeasurementGuardWithLog;
+        #[derive(Default)]
+        pub(crate) struct AsyncAllocBridge;
+        impl AsyncAllocBridge {
+            #[inline]
+            pub(crate) fn add(&self, _bytes: u64, _count: u64) {}
+        }
+        pub use timing::guard::MeasurementGuard as MeasurementGuardAsync;
+        pub use timing::guard::MeasurementGuard as MeasurementGuardSync;
+        pub(crate) use timing::guard::MeasurementGuardWithLog as MeasurementGuardAsyncWithLog;
+        pub(crate) use timing::guard::MeasurementGuardWithLog as MeasurementGuardSyncWithLog;
     }
 }
 
@@ -69,19 +79,114 @@ pub(crate) static EXCLUDE_WRAPPER: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(false)
 });
 
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
-impl MeasurementGuard {
-    pub fn build(measurement_name: &'static str, wrapper: bool, is_async: bool) -> Self {
-        let skipped = !wrapper && !is_focused(measurement_name);
-        MeasurementGuard::new(measurement_name, wrapper, skipped, is_async)
+#[doc(hidden)]
+#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
+pub fn build_measurement_guard_sync(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> MeasurementGuardSync {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    MeasurementGuardSync::new(measurement_name, wrapper, skipped)
+}
+
+#[doc(hidden)]
+#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
+pub fn build_measurement_guard_async(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> MeasurementGuardAsync {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            MeasurementGuardAsync::new(measurement_name, wrapper, skipped, None)
+        } else {
+            MeasurementGuardAsync::new(measurement_name, wrapper, skipped)
+        }
     }
 }
 
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
-impl MeasurementGuardWithLog {
-    pub fn build(measurement_name: &'static str, wrapper: bool, is_async: bool) -> Self {
-        let skipped = !wrapper && !is_focused(measurement_name);
-        MeasurementGuardWithLog::new(measurement_name, wrapper, skipped, is_async)
+#[inline]
+fn make_alloc_bridge(skipped: bool) -> Option<std::sync::Arc<AsyncAllocBridge>> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            if skipped { None } else { Some(std::sync::Arc::new(AsyncAllocBridge::default())) }
+        } else {
+            let _ = skipped;
+            None
+        }
+    }
+}
+
+#[inline]
+fn build_measurement_guard_async_with_bridge(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> (
+    MeasurementGuardAsync,
+    Option<std::sync::Arc<AsyncAllocBridge>>,
+) {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    let alloc_bridge = make_alloc_bridge(skipped);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            let guard = MeasurementGuardAsync::new(
+                measurement_name,
+                wrapper,
+                skipped,
+                alloc_bridge.clone(),
+            );
+            (guard, alloc_bridge)
+        } else {
+            let guard = MeasurementGuardAsync::new(measurement_name, wrapper, skipped);
+            (guard, alloc_bridge)
+        }
+    }
+}
+
+#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
+fn build_measurement_guard_sync_with_log(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> MeasurementGuardSyncWithLog {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    MeasurementGuardSyncWithLog::new(measurement_name, wrapper, skipped)
+}
+
+#[cfg(not(feature = "hotpath-alloc"))]
+#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
+fn build_measurement_guard_async_with_log(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> MeasurementGuardAsyncWithLog {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    MeasurementGuardAsyncWithLog::new(measurement_name, wrapper, skipped)
+}
+
+#[inline]
+fn build_measurement_guard_async_with_log_bridge(
+    measurement_name: &'static str,
+    wrapper: bool,
+) -> (
+    MeasurementGuardAsyncWithLog,
+    Option<std::sync::Arc<AsyncAllocBridge>>,
+) {
+    let skipped = !wrapper && !is_focused(measurement_name);
+    let alloc_bridge = make_alloc_bridge(skipped);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            let guard = MeasurementGuardAsyncWithLog::new(
+                measurement_name,
+                wrapper,
+                skipped,
+                alloc_bridge.clone(),
+            );
+            (guard, alloc_bridge)
+        } else {
+            let guard = MeasurementGuardAsyncWithLog::new(measurement_name, wrapper, skipped);
+            (guard, alloc_bridge)
+        }
     }
 }
 
@@ -94,7 +199,7 @@ pub fn measure_with_log<T: std::fmt::Debug, F: FnOnce() -> T>(
     wrapper: bool,
     f: F,
 ) -> T {
-    let guard = MeasurementGuardWithLog::build(name, wrapper, false);
+    let guard = build_measurement_guard_sync_with_log(name, wrapper);
     let result = f();
     guard.finish_with_result(&result);
     result
@@ -103,14 +208,96 @@ pub fn measure_with_log<T: std::fmt::Debug, F: FnOnce() -> T>(
 /// Measure an async function and log its return value.
 #[doc(hidden)]
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-#[cfg_attr(feature = "hotpath-meta", hotpath_meta::future_fn(log = true))]
 pub async fn measure_with_log_async<T: std::fmt::Debug, F, Fut>(name: &'static str, f: F) -> T
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = T>,
 {
-    let guard = MeasurementGuardWithLog::build(name, false, true);
-    let result = f().await;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            let (guard, alloc_bridge) = build_measurement_guard_async_with_log_bridge(name, false);
+            let result = crate::futures::wrapper::InstrumentedFutureLog::new(
+                f(),
+                name,
+                None,
+                alloc_bridge,
+                false,
+            )
+            .await;
+            guard.finish_with_result(&result);
+            result
+        } else {
+            let guard = build_measurement_guard_async_with_log(name, false);
+            let result = f().await;
+            guard.finish_with_result(&result);
+            result
+        }
+    }
+}
+
+/// Measure an async function without emitting future events.
+#[doc(hidden)]
+pub async fn measure_async<T, Fut>(name: &'static str, fut: Fut) -> T
+where
+    Fut: Future<Output = T>,
+{
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hotpath-alloc")] {
+            let (_guard, alloc_bridge) = build_measurement_guard_async_with_bridge(name, false);
+            crate::futures::wrapper::InstrumentedFuture::new(
+                fut,
+                name,
+                None,
+                alloc_bridge,
+                false,
+            )
+            .await
+        } else {
+            let _guard = build_measurement_guard_async(name, false);
+            fut.await
+        }
+    }
+}
+
+/// Measure an async function with explicit future instrumentation (`measure(future = true)`).
+#[doc(hidden)]
+pub async fn measure_with_future_async<T, Fut>(
+    name: &'static str,
+    future_loc: &'static str,
+    fut: Fut,
+) -> T
+where
+    Fut: Future<Output = T>,
+{
+    crate::futures::init_futures_state();
+
+    let (_guard, alloc_bridge) = build_measurement_guard_async_with_bridge(name, false);
+    crate::futures::wrapper::InstrumentedFuture::new(fut, future_loc, None, alloc_bridge, true)
+        .await
+}
+
+/// Measure an async function with explicit future instrumentation and return-value logs.
+#[doc(hidden)]
+pub async fn measure_with_future_log_async<T, Fut>(
+    name: &'static str,
+    future_loc: &'static str,
+    fut: Fut,
+) -> T
+where
+    T: std::fmt::Debug,
+    Fut: Future<Output = T>,
+{
+    crate::futures::init_futures_state();
+
+    let (guard, alloc_bridge) = build_measurement_guard_async_with_log_bridge(name, false);
+    let result = crate::futures::wrapper::InstrumentedFutureLog::new(
+        fut,
+        future_loc,
+        None,
+        alloc_bridge,
+        true,
+    )
+    .await;
     guard.finish_with_result(&result);
     result
 }

--- a/crates/hotpath/src/lib_on/functions/alloc/guard.rs
+++ b/crates/hotpath/src/lib_on/functions/alloc/guard.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 #[cfg(target_os = "linux")]
@@ -5,6 +7,28 @@ use quanta::Instant;
 
 #[cfg(not(target_os = "linux"))]
 use std::time::Instant;
+
+#[derive(Debug, Default)]
+pub(crate) struct AsyncAllocBridge {
+    bytes_total: AtomicU64,
+    count_total: AtomicU64,
+}
+
+impl AsyncAllocBridge {
+    #[inline]
+    pub(crate) fn add(&self, bytes: u64, count: u64) {
+        self.bytes_total.fetch_add(bytes, Ordering::Relaxed);
+        self.count_total.fetch_add(count, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn snapshot(&self) -> (Option<u64>, Option<u64>) {
+        (
+            Some(self.bytes_total.load(Ordering::Relaxed)),
+            Some(self.count_total.load(Ordering::Relaxed)),
+        )
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AllocMetric {
@@ -31,34 +55,112 @@ pub(crate) static ALLOC_SELF: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(false)
 });
 
-pub(crate) static UNSAFE_ASYNC_ALLOC: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("HOTPATH_UNSAFE_ASYNC_ALLOC")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false)
-});
+#[inline]
+pub(crate) fn push_alloc_stack() {
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        let current_depth = stack.depth.get();
+        stack.depth.set(current_depth + 1);
+        assert!((stack.depth.get() as usize) < crate::functions::alloc::core::MAX_DEPTH);
+        let depth = stack.depth.get() as usize;
+        stack.elements[depth].bytes_total.set(0);
+        stack.elements[depth].count_total.set(0);
+    });
+}
+
+#[inline]
+pub(crate) fn pop_alloc_stack() -> (u64, u64) {
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        assert!(stack.depth.get() > 0, "pop_alloc_stack called with depth 0");
+        let depth = stack.depth.get() as usize;
+        let bytes = stack.elements[depth].bytes_total.get();
+        let count = stack.elements[depth].count_total.get();
+
+        stack.depth.set(stack.depth.get() - 1);
+
+        if !*ALLOC_SELF {
+            let parent = stack.depth.get() as usize;
+            stack.elements[parent]
+                .bytes_total
+                .set(stack.elements[parent].bytes_total.get() + bytes);
+            stack.elements[parent]
+                .count_total
+                .set(stack.elements[parent].count_total.get() + count);
+        }
+
+        (bytes, count)
+    })
+}
+
+#[inline]
+fn send_alloc_measurement(
+    name: &'static str,
+    bytes_total: Option<u64>,
+    count_total: Option<u64>,
+    duration: std::time::Duration,
+    wrapper: bool,
+    tid: Option<u64>,
+) {
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        stack.tracking_enabled.set(false);
+    });
+
+    crate::functions::alloc::state::send_alloc_measurement(
+        name,
+        bytes_total,
+        count_total,
+        duration,
+        wrapper,
+        tid,
+    );
+
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        stack.tracking_enabled.set(true);
+    });
+}
+
+#[inline]
+fn send_alloc_measurement_with_log(
+    name: &'static str,
+    bytes_total: Option<u64>,
+    count_total: Option<u64>,
+    duration: std::time::Duration,
+    wrapper: bool,
+    tid: Option<u64>,
+    result_log: Option<String>,
+) {
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        stack.tracking_enabled.set(false);
+    });
+
+    crate::functions::alloc::state::send_alloc_measurement_with_log(
+        name,
+        bytes_total,
+        count_total,
+        duration,
+        wrapper,
+        tid,
+        result_log,
+    );
+
+    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
+        stack.tracking_enabled.set(true);
+    });
+}
 
 #[must_use = "guard is dropped immediately without measuring anything"]
-pub struct MeasurementGuard {
+pub struct MeasurementGuardSync {
     name: &'static str,
     wrapper: bool,
     tid: u64,
     start: Instant,
     skipped: bool,
-    is_async: bool,
 }
 
-impl MeasurementGuard {
+impl MeasurementGuardSync {
     #[inline]
-    pub fn new(name: &'static str, wrapper: bool, skipped: bool, is_async: bool) -> Self {
-        if !skipped && (!is_async || *UNSAFE_ASYNC_ALLOC) {
-            super::core::ALLOCATIONS.with(|stack| {
-                let current_depth = stack.depth.get();
-                stack.depth.set(current_depth + 1);
-                assert!((stack.depth.get() as usize) < super::core::MAX_DEPTH);
-                let depth = stack.depth.get() as usize;
-                stack.elements[depth].bytes_total.set(0);
-                stack.elements[depth].count_total.set(0);
-            });
+    pub fn new(name: &'static str, wrapper: bool, skipped: bool) -> Self {
+        if !skipped {
+            push_alloc_stack();
         }
 
         Self {
@@ -67,12 +169,11 @@ impl MeasurementGuard {
             tid: crate::tid::current_tid(),
             start: Instant::now(),
             skipped,
-            is_async,
         }
     }
 }
 
-impl Drop for MeasurementGuard {
+impl Drop for MeasurementGuardSync {
     #[inline]
     fn drop(&mut self) {
         if self.skipped {
@@ -82,36 +183,14 @@ impl Drop for MeasurementGuard {
         let duration = self.start.elapsed();
         let cross_thread = crate::tid::current_tid() != self.tid;
 
-        let (bytes_total, count_total) = if (self.is_async && !*UNSAFE_ASYNC_ALLOC) || cross_thread
-        {
+        let (bytes_total, count_total) = if cross_thread {
             (None, None)
         } else {
-            super::core::ALLOCATIONS.with(|stack| {
-                let depth = stack.depth.get() as usize;
-                let bytes = stack.elements[depth].bytes_total.get();
-                let count = stack.elements[depth].count_total.get();
-
-                stack.depth.set(stack.depth.get() - 1);
-
-                if !*ALLOC_SELF {
-                    let parent = stack.depth.get() as usize;
-                    stack.elements[parent]
-                        .bytes_total
-                        .set(stack.elements[parent].bytes_total.get() + bytes);
-                    stack.elements[parent]
-                        .count_total
-                        .set(stack.elements[parent].count_total.get() + count);
-                }
-
-                (Some(bytes), Some(count))
-            })
+            let (bytes, count) = pop_alloc_stack();
+            (Some(bytes), Some(count))
         };
 
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(false);
-        });
-
-        super::state::send_alloc_measurement(
+        send_alloc_measurement(
             self.name,
             bytes_total,
             count_total,
@@ -119,36 +198,77 @@ impl Drop for MeasurementGuard {
             self.wrapper,
             Some(self.tid),
         );
-
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(true);
-        });
     }
 }
 
 #[must_use = "guard is dropped immediately without measuring anything"]
-pub(crate) struct MeasurementGuardWithLog {
+pub struct MeasurementGuardAsync {
+    name: &'static str,
+    wrapper: bool,
+    tid: u64,
+    start: Instant,
+    skipped: bool,
+    alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+}
+
+impl MeasurementGuardAsync {
+    #[inline]
+    pub(crate) fn new(
+        name: &'static str,
+        wrapper: bool,
+        skipped: bool,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+    ) -> Self {
+        Self {
+            name,
+            wrapper,
+            tid: crate::tid::current_tid(),
+            start: Instant::now(),
+            skipped,
+            alloc_bridge,
+        }
+    }
+}
+
+impl Drop for MeasurementGuardAsync {
+    #[inline]
+    fn drop(&mut self) {
+        if self.skipped {
+            return;
+        }
+
+        let duration = self.start.elapsed();
+        let (bytes_total, count_total) = self
+            .alloc_bridge
+            .as_ref()
+            .map_or((None, None), |bridge| bridge.snapshot());
+
+        send_alloc_measurement(
+            self.name,
+            bytes_total,
+            count_total,
+            duration,
+            self.wrapper,
+            Some(self.tid),
+        );
+    }
+}
+
+#[must_use = "guard is dropped immediately without measuring anything"]
+pub(crate) struct MeasurementGuardSyncWithLog {
     name: &'static str,
     wrapper: bool,
     tid: u64,
     start: Instant,
     finished: bool,
     skipped: bool,
-    is_async: bool,
 }
 
-impl MeasurementGuardWithLog {
+impl MeasurementGuardSyncWithLog {
     #[inline]
-    pub fn new(name: &'static str, wrapper: bool, skipped: bool, is_async: bool) -> Self {
-        if !skipped && (!is_async || *UNSAFE_ASYNC_ALLOC) {
-            super::core::ALLOCATIONS.with(|stack| {
-                let current_depth = stack.depth.get();
-                stack.depth.set(current_depth + 1);
-                assert!((stack.depth.get() as usize) < super::core::MAX_DEPTH);
-                let depth = stack.depth.get() as usize;
-                stack.elements[depth].bytes_total.set(0);
-                stack.elements[depth].count_total.set(0);
-            });
+    pub fn new(name: &'static str, wrapper: bool, skipped: bool) -> Self {
+        if !skipped {
+            push_alloc_stack();
         }
 
         Self {
@@ -158,7 +278,6 @@ impl MeasurementGuardWithLog {
             start: Instant::now(),
             finished: false,
             skipped,
-            is_async,
         }
     }
 
@@ -168,41 +287,19 @@ impl MeasurementGuardWithLog {
         if self.skipped {
             return;
         }
-        let result_str = crate::output::format_debug_truncated(result);
 
         let duration = self.start.elapsed();
+        let result_str = crate::output::format_debug_truncated(result);
         let cross_thread = crate::tid::current_tid() != self.tid;
 
-        let (bytes_total, count_total) = if (self.is_async && !*UNSAFE_ASYNC_ALLOC) || cross_thread
-        {
+        let (bytes_total, count_total) = if cross_thread {
             (None, None)
         } else {
-            super::core::ALLOCATIONS.with(|stack| {
-                let depth = stack.depth.get() as usize;
-                let bytes = stack.elements[depth].bytes_total.get();
-                let count = stack.elements[depth].count_total.get();
-
-                stack.depth.set(stack.depth.get() - 1);
-
-                if !*ALLOC_SELF {
-                    let parent = stack.depth.get() as usize;
-                    stack.elements[parent]
-                        .bytes_total
-                        .set(stack.elements[parent].bytes_total.get() + bytes);
-                    stack.elements[parent]
-                        .count_total
-                        .set(stack.elements[parent].count_total.get() + count);
-                }
-
-                (Some(bytes), Some(count))
-            })
+            let (bytes, count) = pop_alloc_stack();
+            (Some(bytes), Some(count))
         };
 
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(false);
-        });
-
-        super::state::send_alloc_measurement_with_log(
+        send_alloc_measurement_with_log(
             self.name,
             bytes_total,
             count_total,
@@ -211,14 +308,10 @@ impl MeasurementGuardWithLog {
             Some(self.tid),
             Some(result_str),
         );
-
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(true);
-        });
     }
 }
 
-impl Drop for MeasurementGuardWithLog {
+impl Drop for MeasurementGuardSyncWithLog {
     #[inline]
     fn drop(&mut self) {
         if self.skipped || self.finished {
@@ -228,36 +321,14 @@ impl Drop for MeasurementGuardWithLog {
         let duration = self.start.elapsed();
         let cross_thread = crate::tid::current_tid() != self.tid;
 
-        let (bytes_total, count_total) = if (self.is_async && !*UNSAFE_ASYNC_ALLOC) || cross_thread
-        {
+        let (bytes_total, count_total) = if cross_thread {
             (None, None)
         } else {
-            super::core::ALLOCATIONS.with(|stack| {
-                let depth = stack.depth.get() as usize;
-                let bytes = stack.elements[depth].bytes_total.get();
-                let count = stack.elements[depth].count_total.get();
-
-                stack.depth.set(stack.depth.get() - 1);
-
-                if !*ALLOC_SELF {
-                    let parent = stack.depth.get() as usize;
-                    stack.elements[parent]
-                        .bytes_total
-                        .set(stack.elements[parent].bytes_total.get() + bytes);
-                    stack.elements[parent]
-                        .count_total
-                        .set(stack.elements[parent].count_total.get() + count);
-                }
-
-                (Some(bytes), Some(count))
-            })
+            let (bytes, count) = pop_alloc_stack();
+            (Some(bytes), Some(count))
         };
 
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(false);
-        });
-
-        super::state::send_alloc_measurement_with_log(
+        send_alloc_measurement_with_log(
             self.name,
             bytes_total,
             count_total,
@@ -266,9 +337,86 @@ impl Drop for MeasurementGuardWithLog {
             Some(self.tid),
             None,
         );
+    }
+}
 
-        super::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(true);
-        });
+#[must_use = "guard is dropped immediately without measuring anything"]
+pub(crate) struct MeasurementGuardAsyncWithLog {
+    name: &'static str,
+    wrapper: bool,
+    tid: u64,
+    start: Instant,
+    finished: bool,
+    skipped: bool,
+    alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+}
+
+impl MeasurementGuardAsyncWithLog {
+    #[inline]
+    pub(crate) fn new(
+        name: &'static str,
+        wrapper: bool,
+        skipped: bool,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+    ) -> Self {
+        Self {
+            name,
+            wrapper,
+            tid: crate::tid::current_tid(),
+            start: Instant::now(),
+            finished: false,
+            skipped,
+            alloc_bridge,
+        }
+    }
+
+    #[inline]
+    pub fn finish_with_result<T: std::fmt::Debug>(mut self, result: &T) {
+        self.finished = true;
+        if self.skipped {
+            return;
+        }
+
+        let duration = self.start.elapsed();
+        let result_str = crate::output::format_debug_truncated(result);
+        let (bytes_total, count_total) = self
+            .alloc_bridge
+            .as_ref()
+            .map_or((None, None), |bridge| bridge.snapshot());
+
+        send_alloc_measurement_with_log(
+            self.name,
+            bytes_total,
+            count_total,
+            duration,
+            self.wrapper,
+            Some(self.tid),
+            Some(result_str),
+        );
+    }
+}
+
+impl Drop for MeasurementGuardAsyncWithLog {
+    #[inline]
+    fn drop(&mut self) {
+        if self.skipped || self.finished {
+            return;
+        }
+
+        let duration = self.start.elapsed();
+        let (bytes_total, count_total) = self
+            .alloc_bridge
+            .as_ref()
+            .map_or((None, None), |bridge| bridge.snapshot());
+
+        send_alloc_measurement_with_log(
+            self.name,
+            bytes_total,
+            count_total,
+            duration,
+            self.wrapper,
+            Some(self.tid),
+            None,
+        );
     }
 }

--- a/crates/hotpath/src/lib_on/functions/timing/guard.rs
+++ b/crates/hotpath/src/lib_on/functions/timing/guard.rs
@@ -19,7 +19,7 @@ pub struct MeasurementGuard {
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
 impl MeasurementGuard {
     #[inline]
-    pub fn new(name: &'static str, wrapper: bool, skipped: bool, _is_async: bool) -> Self {
+    pub fn new(name: &'static str, wrapper: bool, skipped: bool) -> Self {
         Self {
             name,
             start: Instant::now(),
@@ -61,7 +61,7 @@ pub(crate) struct MeasurementGuardWithLog {
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
 impl MeasurementGuardWithLog {
     #[inline]
-    pub fn new(name: &'static str, wrapper: bool, skipped: bool, _is_async: bool) -> Self {
+    pub fn new(name: &'static str, wrapper: bool, skipped: bool) -> Self {
         Self {
             name,
             start: Instant::now(),

--- a/crates/hotpath/src/lib_on/futures.rs
+++ b/crates/hotpath/src/lib_on/futures.rs
@@ -64,6 +64,8 @@ pub(crate) struct FutureEntry {
     pub(crate) logs_count: u64,
     pub(crate) total_poll_count: u64,
     pub(crate) total_poll_duration_ns: u64,
+    pub(crate) total_poll_alloc_bytes: Option<u64>,
+    pub(crate) total_poll_alloc_count: Option<u64>,
 }
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
@@ -76,6 +78,8 @@ impl FutureEntry {
             logs_count: 0,
             total_poll_count: 0,
             total_poll_duration_ns: 0,
+            total_poll_alloc_bytes: None,
+            total_poll_alloc_count: None,
         }
     }
 
@@ -85,6 +89,14 @@ impl FutureEntry {
 
     pub(crate) fn total_poll_duration_ns(&self) -> u64 {
         self.total_poll_duration_ns
+    }
+
+    pub(crate) fn total_poll_alloc_bytes(&self) -> Option<u64> {
+        self.total_poll_alloc_bytes
+    }
+
+    pub(crate) fn total_poll_alloc_count(&self) -> Option<u64> {
+        self.total_poll_alloc_count
     }
 }
 
@@ -122,6 +134,8 @@ impl From<&FutureEntry> for JsonFutureEntry {
             call_count: stats.logs_count,
             total_polls: stats.total_polls(),
             total_poll_duration_ns: stats.total_poll_duration_ns(),
+            total_poll_alloc_bytes: stats.total_poll_alloc_bytes(),
+            total_poll_alloc_count: stats.total_poll_alloc_count(),
         }
     }
 }
@@ -151,6 +165,8 @@ pub(crate) enum FutureEvent {
         result: PollResult,
         log_message: Option<String>,
         poll_duration_ns: u64,
+        poll_alloc_bytes: Option<u64>,
+        poll_alloc_count: Option<u64>,
     },
     Completed {
         future_id: u32,
@@ -285,6 +301,12 @@ pub fn init_futures_state() {
 /// Process a future event and update stats.
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
 fn process_future_event(state: &mut FuturesInternalState, event: FutureEvent) {
+    fn add_optional(total: &mut Option<u64>, delta: Option<u64>) {
+        if let Some(delta) = delta {
+            *total = Some(total.unwrap_or(0) + delta);
+        }
+    }
+
     match event {
         FutureEvent::Created {
             future_id,
@@ -317,18 +339,33 @@ fn process_future_event(state: &mut FuturesInternalState, event: FutureEvent) {
             result,
             log_message,
             poll_duration_ns,
+            poll_alloc_bytes,
+            poll_alloc_count,
         } => {
             if let Some(future_stats) = state.stats.get_mut(&future_id) {
                 future_stats.total_poll_count += 1;
                 future_stats.total_poll_duration_ns += poll_duration_ns;
+                add_optional(&mut future_stats.total_poll_alloc_bytes, poll_alloc_bytes);
+                add_optional(&mut future_stats.total_poll_alloc_count, poll_alloc_count);
             }
             if let Some(entry_logs) = state.logs.get_mut(&future_id) {
                 if let Some(call) = entry_logs.find_call_mut(call_id) {
                     call.poll_count += 1;
                     call.total_poll_duration_ns += poll_duration_ns;
                     call.last_poll_duration_ns = poll_duration_ns;
+                    add_optional(&mut call.total_poll_alloc_bytes, poll_alloc_bytes);
+                    add_optional(&mut call.total_poll_alloc_count, poll_alloc_count);
+                    call.last_poll_alloc_bytes = poll_alloc_bytes;
                     if poll_duration_ns > call.max_poll_duration_ns {
                         call.max_poll_duration_ns = poll_duration_ns;
+                    }
+                    if let Some(poll_alloc_bytes) = poll_alloc_bytes {
+                        if call
+                            .max_poll_alloc_bytes
+                            .is_none_or(|max| poll_alloc_bytes > max)
+                        {
+                            call.max_poll_alloc_bytes = Some(poll_alloc_bytes);
+                        }
                     }
                     match result {
                         PollResult::Pending => {
@@ -365,7 +402,11 @@ fn process_future_event(state: &mut FuturesInternalState, event: FutureEvent) {
 
 /// Send a future event to the background thread.
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-pub(crate) fn send_future_event(event: FutureEvent) {
+pub(crate) fn send_future_event(visible: bool, event: FutureEvent) {
+    if !visible {
+        return;
+    };
+
     if let Some(state) = FUTURES_STATE.get() {
         let _ = state.event_tx.send(event);
     }
@@ -393,7 +434,7 @@ impl<F: std::future::Future> InstrumentFuture for F {
     type Output = InstrumentedFuture<F>;
 
     fn instrument_future(self, source: &'static str, label: Option<String>) -> Self::Output {
-        InstrumentedFuture::new(self, source, label)
+        InstrumentedFuture::new(self, source, label, None, true)
     }
 }
 
@@ -404,7 +445,7 @@ where
     type Output = InstrumentedFutureLog<F>;
 
     fn instrument_future_log(self, source: &'static str, label: Option<String>) -> Self::Output {
-        InstrumentedFutureLog::new(self, source, label)
+        InstrumentedFutureLog::new(self, source, label, None, true)
     }
 }
 
@@ -445,6 +486,8 @@ pub(crate) fn get_future_logs_list(future_id: u32) -> Option<FutureLogsList> {
         call_count: stats.logs_count,
         total_polls: stats.total_polls(),
         total_poll_duration_ns: stats.total_poll_duration_ns(),
+        total_poll_alloc_bytes: stats.total_poll_alloc_bytes(),
+        total_poll_alloc_count: stats.total_poll_alloc_count(),
         calls: entry_logs.logs.iter().rev().cloned().collect(),
     })
 }

--- a/crates/hotpath/src/lib_on/futures/wrapper.rs
+++ b/crates/hotpath/src/lib_on/futures/wrapper.rs
@@ -5,6 +5,7 @@ use crate::output::format_debug_truncated;
 use super::{
     get_or_create_future_id, send_future_event, FutureEvent, PollResult, FUTURE_CALL_ID_COUNTER,
 };
+use crate::functions::AsyncAllocBridge;
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::mem::ManuallyDrop;
@@ -57,6 +58,24 @@ fn create_instrumented_waker(waker: &Waker) -> Waker {
     unsafe { Waker::from_raw(raw) }
 }
 
+#[cfg(feature = "hotpath-alloc")]
+#[inline]
+fn measure_poll_alloc<R>(poll_fn: impl FnOnce() -> R) -> (R, Option<u64>, Option<u64>) {
+    crate::functions::alloc::guard::push_alloc_stack();
+
+    let result = poll_fn();
+
+    let (bytes, count) = crate::functions::alloc::guard::pop_alloc_stack();
+
+    (result, Some(bytes), Some(count))
+}
+
+#[cfg(not(feature = "hotpath-alloc"))]
+#[inline]
+fn measure_poll_alloc<R>(poll_fn: impl FnOnce() -> R) -> (R, Option<u64>, Option<u64>) {
+    (poll_fn(), None, None)
+}
+
 pin_project! {
     /// A wrapper around a future that tracks lifecycle events.
     ///
@@ -73,12 +92,14 @@ pin_project! {
         future_id: u32,
         call_id: u32,
         completed: bool,
+        visible: bool,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
     }
 
     impl<F: Future> PinnedDrop for InstrumentedFuture<F> {
         fn drop(this: Pin<&mut Self>) {
             if !this.completed {
-                send_future_event(FutureEvent::Cancelled { future_id: this.future_id, call_id: this.call_id });
+                send_future_event(this.visible, FutureEvent::Cancelled { future_id: this.future_id, call_id: this.call_id });
             }
         }
     }
@@ -86,26 +107,41 @@ pin_project! {
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
 impl<F: Future> InstrumentedFuture<F> {
-    /// Create a new instrumented future.
-    pub fn new(inner: F, location: &'static str, label: Option<String>) -> Self {
-        let (future_id, is_new) = get_or_create_future_id(location);
-        let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn new(
+        inner: F,
+        location: &'static str,
+        label: Option<String>,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+        visible: bool,
+    ) -> Self {
+        let (future_id, call_id) = if visible {
+            let (future_id, is_new) = get_or_create_future_id(location);
+            let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
 
-        if is_new {
-            send_future_event(FutureEvent::Created {
-                future_id,
-                source: location,
-                display_label: label,
-            });
-        }
+            if is_new {
+                send_future_event(
+                    true,
+                    FutureEvent::Created {
+                        future_id,
+                        source: location,
+                        display_label: label,
+                    },
+                );
+            }
 
-        send_future_event(FutureEvent::CallCreated { future_id, call_id });
+            send_future_event(true, FutureEvent::CallCreated { future_id, call_id });
+            (future_id, call_id)
+        } else {
+            (0, 0)
+        };
 
         Self {
             inner,
             future_id,
             call_id,
             completed: false,
+            visible,
+            alloc_bridge,
         }
     }
 }
@@ -117,13 +153,22 @@ impl<F: Future> Future for InstrumentedFuture<F> {
         let this = self.project();
         let future_id = *this.future_id;
         let call_id = *this.call_id;
+        let visible = *this.visible;
 
         let instrumented_waker = create_instrumented_waker(cx.waker());
         let mut instrumented_cx = Context::from_waker(&instrumented_waker);
 
         let start = Instant::now();
-        let result = this.inner.poll(&mut instrumented_cx);
+        let (result, poll_alloc_bytes, poll_alloc_count) =
+            measure_poll_alloc(|| this.inner.poll(&mut instrumented_cx));
         let poll_duration_ns = start.elapsed().as_nanos() as u64;
+        if let (Some(bytes), Some(count), Some(bridge)) = (
+            poll_alloc_bytes,
+            poll_alloc_count,
+            this.alloc_bridge.as_ref(),
+        ) {
+            bridge.add(bytes, count);
+        }
 
         let poll_result = match &result {
             Poll::Pending => PollResult::Pending,
@@ -133,16 +178,21 @@ impl<F: Future> Future for InstrumentedFuture<F> {
             }
         };
 
-        send_future_event(FutureEvent::Polled {
-            future_id,
-            call_id,
-            result: poll_result,
-            log_message: None,
-            poll_duration_ns,
-        });
+        send_future_event(
+            visible,
+            FutureEvent::Polled {
+                future_id,
+                call_id,
+                result: poll_result,
+                log_message: None,
+                poll_duration_ns,
+                poll_alloc_bytes,
+                poll_alloc_count,
+            },
+        );
 
         if *this.completed {
-            send_future_event(FutureEvent::Completed { future_id, call_id });
+            send_future_event(visible, FutureEvent::Completed { future_id, call_id });
         }
 
         result
@@ -164,12 +214,14 @@ pin_project! {
         future_id: u32,
         call_id: u32,
         completed: bool,
+        visible: bool,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
     }
 
     impl<F: Future> PinnedDrop for InstrumentedFutureLog<F> {
         fn drop(this: Pin<&mut Self>) {
             if !this.completed {
-                send_future_event(FutureEvent::Cancelled { future_id: this.future_id, call_id: this.call_id });
+                send_future_event(this.visible, FutureEvent::Cancelled { future_id: this.future_id, call_id: this.call_id });
             }
         }
     }
@@ -178,25 +230,41 @@ pin_project! {
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure_all)]
 impl<F: Future> InstrumentedFutureLog<F> {
     /// Create a new instrumented future with logging.
-    pub fn new(inner: F, location: &'static str, label: Option<String>) -> Self {
-        let (future_id, is_new) = get_or_create_future_id(location);
-        let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn new(
+        inner: F,
+        location: &'static str,
+        label: Option<String>,
+        alloc_bridge: Option<Arc<AsyncAllocBridge>>,
+        visible: bool,
+    ) -> Self {
+        let (future_id, call_id) = if visible {
+            let (future_id, is_new) = get_or_create_future_id(location);
+            let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
 
-        if is_new {
-            send_future_event(FutureEvent::Created {
-                future_id,
-                source: location,
-                display_label: label,
-            });
-        }
+            if is_new {
+                send_future_event(
+                    true,
+                    FutureEvent::Created {
+                        future_id,
+                        source: location,
+                        display_label: label,
+                    },
+                );
+            }
 
-        send_future_event(FutureEvent::CallCreated { future_id, call_id });
+            send_future_event(true, FutureEvent::CallCreated { future_id, call_id });
+            (future_id, call_id)
+        } else {
+            (0, 0)
+        };
 
         Self {
             inner,
             future_id,
             call_id,
             completed: false,
+            visible,
+            alloc_bridge,
         }
     }
 }
@@ -211,13 +279,22 @@ where
         let this = self.project();
         let future_id = *this.future_id;
         let call_id = *this.call_id;
+        let visible = *this.visible;
 
         let instrumented_waker = create_instrumented_waker(cx.waker());
         let mut instrumented_cx = Context::from_waker(&instrumented_waker);
 
         let start = Instant::now();
-        let result = this.inner.poll(&mut instrumented_cx);
+        let (result, poll_alloc_bytes, poll_alloc_count) =
+            measure_poll_alloc(|| this.inner.poll(&mut instrumented_cx));
         let poll_duration_ns = start.elapsed().as_nanos() as u64;
+        if let (Some(bytes), Some(count), Some(bridge)) = (
+            poll_alloc_bytes,
+            poll_alloc_count,
+            this.alloc_bridge.as_ref(),
+        ) {
+            bridge.add(bytes, count);
+        }
 
         let (poll_result, log_message) = match &result {
             Poll::Pending => (PollResult::Pending, None),
@@ -227,16 +304,21 @@ where
             }
         };
 
-        send_future_event(FutureEvent::Polled {
-            future_id,
-            call_id,
-            result: poll_result,
-            log_message,
-            poll_duration_ns,
-        });
+        send_future_event(
+            visible,
+            FutureEvent::Polled {
+                future_id,
+                call_id,
+                result: poll_result,
+                log_message,
+                poll_duration_ns,
+                poll_alloc_bytes,
+                poll_alloc_count,
+            },
+        );
 
         if *this.completed {
-            send_future_event(FutureEvent::Completed { future_id, call_id });
+            send_future_event(visible, FutureEvent::Completed { future_id, call_id });
         }
 
         result

--- a/crates/hotpath/src/lib_on/hotpath_guard.rs
+++ b/crates/hotpath/src/lib_on/hotpath_guard.rs
@@ -46,7 +46,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use crate::functions::MeasurementGuard;
+use crate::functions::MeasurementGuardSync;
 use crate::Format;
 
 /// Builder for [`HotpathGuard`] — a programmatic alternative to the
@@ -253,7 +253,7 @@ impl HotpathGuardBuilder {
 pub struct HotpathGuard {
     state: Arc<RwLock<FunctionsState>>,
     format: Format,
-    wrapper_guard: Option<MeasurementGuard>,
+    wrapper_guard: Option<MeasurementGuardSync>,
     output_path: Option<PathBuf>,
     sections: Vec<Section>,
     start_time: Instant,
@@ -505,7 +505,7 @@ impl HotpathGuard {
 
         crate::cpu_baseline::init_cpu_baseline();
 
-        let wrapper_guard = MeasurementGuard::build(caller_name, true, false);
+        let wrapper_guard = crate::functions::build_measurement_guard_sync(caller_name, true);
 
         #[cfg(feature = "hotpath-alloc")]
         crate::functions::alloc::core::ALLOCATIONS.with(|stack| {

--- a/crates/hotpath/src/lib_on/report.rs
+++ b/crates/hotpath/src/lib_on/report.rs
@@ -244,23 +244,38 @@ pub(crate) fn report_futures_table(
         styled_header("Polls"),
         styled_header("Avg Poll"),
         styled_header("Total Poll"),
+        styled_header("Avg Alloc"),
+        styled_header("Total Alloc"),
     ]));
 
     for future_stats in futures {
         let label = resolve_label(future_stats.source, future_stats.label.as_deref(), None);
+        let total_calls = future_stats.logs_count;
         let total_polls = future_stats.total_polls();
         let total_poll_dur = future_stats.total_poll_duration_ns();
+        let total_alloc_bytes_across_polls = future_stats.total_poll_alloc_bytes();
         let avg_poll = if total_polls > 0 {
             format_duration(total_poll_dur / total_polls)
         } else {
             "-".to_string()
         };
+        let avg_alloc_per_call = match total_alloc_bytes_across_polls {
+            Some(total_alloc_bytes) if total_calls > 0 => {
+                format_bytes(total_alloc_bytes / total_calls)
+            }
+            _ => "-".to_string(),
+        };
+        let total_alloc = total_alloc_bytes_across_polls
+            .map(format_bytes)
+            .unwrap_or_else(|| "-".to_string());
         table.add_row(Row::new(vec![
             Cell::new(&label),
-            Cell::new(&future_stats.logs_count.to_string()),
+            Cell::new(&total_calls.to_string()),
             Cell::new(&total_polls.to_string()),
             Cell::new(&avg_poll),
             Cell::new(&format_duration(total_poll_dur)),
+            Cell::new(&avg_alloc_per_call),
+            Cell::new(&total_alloc),
         ]));
     }
 

--- a/crates/hotpath/tests/functions.rs
+++ b/crates/hotpath/tests/functions.rs
@@ -1157,9 +1157,9 @@ pub mod tests {
         }
     }
 
-    // HOTPATH_UNSAFE_ASYNC_ALLOC=true cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
+    // cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
     #[test]
-    fn test_unsafe_async_alloc() {
+    fn test_async_alloc_is_reported() {
         use hotpath::json::JsonReport;
 
         let output = Command::new("cargo")
@@ -1172,7 +1172,6 @@ pub mod tests {
                 "--features",
                 "hotpath,hotpath-alloc",
             ])
-            .env("HOTPATH_UNSAFE_ASYNC_ALLOC", "true")
             .env("HOTPATH_METRICS_SERVER_OFF", "true")
             .output()
             .expect("Failed to execute command");
@@ -1199,15 +1198,7 @@ pub mod tests {
 
         assert_ne!(
             async_fn.total, "N/A",
-            "async_function should have alloc data with HOTPATH_UNSAFE_ASYNC_ALLOC=true, got N/A"
-        );
-
-        let bytes =
-            hotpath::parse_bytes(&async_fn.total).expect("Failed to parse async_function total");
-        assert!(
-            bytes > 0,
-            "async_function should have non-zero alloc bytes, got {}",
-            bytes
+            "async_function alloc should be reported when hotpath-alloc is enabled"
         );
     }
 

--- a/crates/test-tokio-async/examples/async_alloc_measure.rs
+++ b/crates/test-tokio-async/examples/async_alloc_measure.rs
@@ -1,0 +1,49 @@
+use std::hint::black_box;
+
+async fn uninstrumented_1kb() -> Vec<u8> {
+    let buf = vec![0u8; 1024];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+    buf
+}
+
+#[hotpath::measure]
+async fn instrumented_1kb() {
+    let buf = vec![0u8; 1024];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+}
+
+#[hotpath::measure]
+async fn uninstrumented_children_2kb() {
+    let a = uninstrumented_1kb().await;
+    let b = uninstrumented_1kb().await;
+    black_box((&a, &b));
+}
+
+#[hotpath::measure(future = true)]
+async fn own_1kb_plus_uninstrumented_child_1kb() {
+    let own = vec![0u8; 1024];
+    black_box(&own);
+    let child = uninstrumented_1kb().await;
+    black_box(&child);
+}
+
+#[hotpath::measure(future = true)]
+async fn own_1kb_plus_uninstrumented_1kb_plus_instrumented_1kb() {
+    let own = vec![0u8; 1024];
+    black_box(&own);
+    let from_uninstrumented = uninstrumented_1kb().await;
+    black_box(&from_uninstrumented);
+    instrumented_1kb().await;
+}
+
+#[tokio::main]
+#[hotpath::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    uninstrumented_children_2kb().await;
+    own_1kb_plus_uninstrumented_child_1kb().await;
+    own_1kb_plus_uninstrumented_1kb_plus_instrumented_1kb().await;
+
+    Ok(())
+}


### PR DESCRIPTION
`MeasurementGuard`/`MeasurementGuardWithLog` replaced with `MeasurementGuardSync`/`MeasurementGuardSyncWithLog`/`MeasurementGuardAsync`/`MeasurementGuardAsyncWithLog`.