### PR TITLE
fix: Dont track instrumentation alloc

### DIFF
--- a/crates/hotpath/src/lib_on.rs
+++ b/crates/hotpath/src/lib_on.rs
@@ -41,6 +41,26 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "hotpath-alloc")] {
         #[global_allocator]
         static GLOBAL: functions::alloc::allocator::CountingAllocator = functions::alloc::allocator::CountingAllocator {};
+
+        #[inline]
+        pub(crate) fn suspend_alloc_tracking() {
+            functions::alloc::core::ALLOCATIONS.with(|stack| {
+                stack.tracking_enabled.set(false);
+            });
+        }
+
+        #[inline]
+        pub(crate) fn resume_alloc_tracking() {
+            functions::alloc::core::ALLOCATIONS.with(|stack| {
+                stack.tracking_enabled.set(true);
+            });
+        }
+    } else {
+        #[inline]
+        pub(crate) fn suspend_alloc_tracking() {}
+
+        #[inline]
+        pub(crate) fn resume_alloc_tracking() {}
     }
 }
 

--- a/crates/hotpath/src/lib_on/functions/alloc/guard.rs
+++ b/crates/hotpath/src/lib_on/functions/alloc/guard.rs
@@ -100,9 +100,7 @@ fn send_alloc_measurement(
     wrapper: bool,
     tid: Option<u64>,
 ) {
-    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-        stack.tracking_enabled.set(false);
-    });
+    crate::lib_on::suspend_alloc_tracking();
 
     crate::functions::alloc::state::send_alloc_measurement(
         name,
@@ -113,9 +111,7 @@ fn send_alloc_measurement(
         tid,
     );
 
-    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-        stack.tracking_enabled.set(true);
-    });
+    crate::lib_on::resume_alloc_tracking();
 }
 
 #[inline]
@@ -128,9 +124,7 @@ fn send_alloc_measurement_with_log(
     tid: Option<u64>,
     result_log: Option<String>,
 ) {
-    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-        stack.tracking_enabled.set(false);
-    });
+    crate::lib_on::suspend_alloc_tracking();
 
     crate::functions::alloc::state::send_alloc_measurement_with_log(
         name,
@@ -142,9 +136,7 @@ fn send_alloc_measurement_with_log(
         result_log,
     );
 
-    crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-        stack.tracking_enabled.set(true);
-    });
+    crate::lib_on::resume_alloc_tracking();
 }
 
 #[must_use = "guard is dropped immediately without measuring anything"]

--- a/crates/hotpath/src/lib_on/futures/wrapper.rs
+++ b/crates/hotpath/src/lib_on/futures/wrapper.rs
@@ -114,6 +114,8 @@ impl<F: Future> InstrumentedFuture<F> {
         alloc_bridge: Option<Arc<AsyncAllocBridge>>,
         visible: bool,
     ) -> Self {
+        crate::lib_on::suspend_alloc_tracking();
+
         let (future_id, call_id) = if visible {
             let (future_id, is_new) = get_or_create_future_id(location);
             let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -135,6 +137,8 @@ impl<F: Future> InstrumentedFuture<F> {
             (0, 0)
         };
 
+        crate::lib_on::resume_alloc_tracking();
+
         Self {
             inner,
             future_id,
@@ -155,8 +159,10 @@ impl<F: Future> Future for InstrumentedFuture<F> {
         let call_id = *this.call_id;
         let visible = *this.visible;
 
+        crate::lib_on::suspend_alloc_tracking();
         let instrumented_waker = create_instrumented_waker(cx.waker());
         let mut instrumented_cx = Context::from_waker(&instrumented_waker);
+        crate::lib_on::resume_alloc_tracking();
 
         let start = Instant::now();
         let (result, poll_alloc_bytes, poll_alloc_count) =
@@ -178,6 +184,7 @@ impl<F: Future> Future for InstrumentedFuture<F> {
             }
         };
 
+        crate::lib_on::suspend_alloc_tracking();
         send_future_event(
             visible,
             FutureEvent::Polled {
@@ -200,6 +207,7 @@ impl<F: Future> Future for InstrumentedFuture<F> {
                 },
             );
         }
+        crate::lib_on::resume_alloc_tracking();
 
         result
     }
@@ -243,6 +251,8 @@ impl<F: Future> InstrumentedFutureLog<F> {
         alloc_bridge: Option<Arc<AsyncAllocBridge>>,
         visible: bool,
     ) -> Self {
+        crate::lib_on::suspend_alloc_tracking();
+
         let (future_id, call_id) = if visible {
             let (future_id, is_new) = get_or_create_future_id(location);
             let call_id = FUTURE_CALL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -263,6 +273,8 @@ impl<F: Future> InstrumentedFutureLog<F> {
         } else {
             (0, 0)
         };
+
+        crate::lib_on::resume_alloc_tracking();
 
         Self {
             inner,
@@ -287,8 +299,10 @@ where
         let call_id = *this.call_id;
         let visible = *this.visible;
 
+        crate::lib_on::suspend_alloc_tracking();
         let instrumented_waker = create_instrumented_waker(cx.waker());
         let mut instrumented_cx = Context::from_waker(&instrumented_waker);
+        crate::lib_on::resume_alloc_tracking();
 
         let start = Instant::now();
         let (result, poll_alloc_bytes, poll_alloc_count) =
@@ -310,6 +324,7 @@ where
             }
         };
 
+        crate::lib_on::suspend_alloc_tracking();
         send_future_event(
             visible,
             FutureEvent::Polled {
@@ -332,6 +347,7 @@ where
                 },
             );
         }
+        crate::lib_on::resume_alloc_tracking();
 
         result
     }

--- a/crates/hotpath/src/lib_on/hotpath_guard.rs
+++ b/crates/hotpath/src/lib_on/hotpath_guard.rs
@@ -279,13 +279,9 @@ impl HotpathGuard {
         futures_limit: usize,
         threads_limit: usize,
     ) -> Self {
+        crate::lib_on::suspend_alloc_tracking();
         #[cfg(feature = "hotpath-alloc")]
-        {
-            crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-                stack.tracking_enabled.set(false);
-            });
-            crate::functions::alloc::core::init_thread_alloc_tracking();
-        }
+        crate::functions::alloc::core::init_thread_alloc_tracking();
 
         let percentiles = percentiles.to_vec();
 
@@ -507,10 +503,7 @@ impl HotpathGuard {
 
         let wrapper_guard = crate::functions::build_measurement_guard_sync(caller_name, true);
 
-        #[cfg(feature = "hotpath-alloc")]
-        crate::functions::alloc::core::ALLOCATIONS.with(|stack| {
-            stack.tracking_enabled.set(true);
-        });
+        crate::lib_on::resume_alloc_tracking();
 
         Self {
             state: Arc::clone(&state_arc),

--- a/crates/hotpath/src/output.rs
+++ b/crates/hotpath/src/output.rs
@@ -293,6 +293,7 @@ impl std::fmt::Write for TruncatingWriter {
 #[cfg(feature = "hotpath")]
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
 pub fn format_debug_truncated(value: &impl std::fmt::Debug) -> String {
+    crate::lib_on::suspend_alloc_tracking();
     use std::fmt::Write;
     let limit = MAX_LOG_LEN.saturating_sub(3);
     let mut writer = TruncatingWriter {
@@ -306,7 +307,9 @@ pub fn format_debug_truncated(value: &impl std::fmt::Debug) -> String {
         writer.buf.push_str("...");
     }
 
-    writer.buf
+    let output = writer.buf;
+    crate::lib_on::resume_alloc_tracking();
+    output
 }
 
 pub fn shorten_function_name(function_name: &str) -> String {

--- a/crates/test-tokio-async/examples/async_alloc_measure.rs
+++ b/crates/test-tokio-async/examples/async_alloc_measure.rs
@@ -38,12 +38,52 @@ async fn own_1kb_plus_uninstrumented_1kb_plus_instrumented_1kb() {
     instrumented_1kb().await;
 }
 
+#[hotpath::measure(future = true)]
+async fn nested_level5() {
+    let buf = vec![0u8; 5120];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+}
+
+#[hotpath::measure(future = true)]
+async fn nested_level4() {
+    let buf = vec![0u8; 5120];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+    nested_level5().await;
+}
+
+#[hotpath::measure(future = true)]
+async fn nested_level3() {
+    let buf = vec![0u8; 5120];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+    nested_level4().await;
+}
+
+#[hotpath::measure(future = true)]
+async fn nested_level2() {
+    let buf = vec![0u8; 5120];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+    nested_level3().await;
+}
+
+#[hotpath::measure(future = true)]
+async fn nested_level1() {
+    let buf = vec![0u8; 5120];
+    black_box(&buf);
+    tokio::task::yield_now().await;
+    nested_level2().await;
+}
+
 #[tokio::main]
 #[hotpath::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     uninstrumented_children_2kb().await;
     own_1kb_plus_uninstrumented_child_1kb().await;
     own_1kb_plus_uninstrumented_1kb_plus_instrumented_1kb().await;
+    nested_level1().await;
 
     Ok(())
 }


### PR DESCRIPTION
Excludes largest hotpath alloc bottleneck from impacting benchmarks
```
alloc-bytes - Cumulative allocation bytes during each function call (including nested calls).
+--------------------+-------------------+---------------------------+-----------------------------+---------------------------+---------------------------+
| Function           | Calls             | Avg                       | P95                         | Total                     | % Total                   |
+--------------------+-------------------+---------------------------+-----------------------------+---------------------------+---------------------------+
| http_worker::fetch | 334 → 339 (+1.5%) | 40.5 KB → 37.8 KB (-6.7%) | 114.5 KB → 107.0 KB (-6.6%) | 13.2 MB → 12.5 MB (-5.3%) | 100.00% → 100.00% (+0.0%) |
+--------------------+-------------------+---------------------------+-----------------------------+---------------------------+---------------------------+
```