### PR TITLE
refactor!: Cleanup macro guard builders logic

### DIFF
--- a/crates/hotpath-macros/src/lib_on.rs
+++ b/crates/hotpath-macros/src/lib_on.rs
@@ -327,25 +327,25 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let sig = &input.sig;
     let block = &input.block;
 
-    let name = sig.ident.to_string();
-    let asyncness = sig.asyncness.is_some();
+    let fn_ident = &sig.ident;
+    let is_async_fn = sig.asyncness.is_some();
 
-    let mut log_result = false;
-    let mut future = false;
+    let mut enable_result_logging = false;
+    let mut enable_future_tracking = false;
 
     if !attr.is_empty() {
         let parser = syn::meta::parser(|meta| {
             if meta.path.is_ident("log") {
                 meta.input.parse::<syn::Token![=]>()?;
                 let lit: syn::LitBool = meta.input.parse()?;
-                log_result = lit.value();
+                enable_result_logging = lit.value();
                 return Ok(());
             }
 
             if meta.path.is_ident("future") {
                 meta.input.parse::<syn::Token![=]>()?;
                 let lit: syn::LitBool = meta.input.parse()?;
-                future = lit.value();
+                enable_future_tracking = lit.value();
                 return Ok(());
             }
 
@@ -357,7 +357,7 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    if future && !asyncness {
+    if enable_future_tracking && !is_async_fn {
         return syn::Error::new_spanned(
             sig.fn_token,
             "future = true can only be used on async functions",
@@ -366,63 +366,42 @@ pub fn measure_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into();
     }
 
-    let fn_name = &sig.ident;
+    let measurement_loc = quote! { concat!(module_path!(), "::", stringify!(#fn_ident)) };
 
-    let wrapped = if future && log_result {
-        let loc = quote! { concat!(module_path!(), "::", #name) };
-        quote! {
-            {
-                const FUTURE_LOC: &'static str = concat!(module_path!(), "::", stringify!(#fn_name));
-                hotpath::functions::measure_with_future_log_async(
-                    #loc,
-                    FUTURE_LOC,
-                    async #block
-                ).await
-            }
-        }
-    } else if future {
-        quote! {
-            {
-                const FUTURE_LOC: &'static str = concat!(module_path!(), "::", stringify!(#fn_name));
-                hotpath::functions::measure_with_future_async(
-                    concat!(module_path!(), "::", #name),
-                    FUTURE_LOC,
-                    async #block
-                ).await
-            }
-        }
-    } else if log_result {
-        let loc = quote! { concat!(module_path!(), "::", #name) };
-        if asyncness {
+    let wrapped_body = if !is_async_fn {
+        if enable_result_logging {
             quote! {
-                hotpath::functions::measure_with_log_async(#loc, || async #block).await
+                hotpath::functions::measure_sync_log(#measurement_loc, || #block)
             }
         } else {
             quote! {
-                hotpath::functions::measure_with_log(#loc, false, || #block)
+                hotpath::functions::measure_sync(#measurement_loc, || #block)
             }
         }
-    } else if asyncness {
+    } else if enable_future_tracking {
+        if enable_result_logging {
+            quote! {
+                hotpath::functions::measure_async_future_log(#measurement_loc, async #block).await
+            }
+        } else {
+            quote! {
+                hotpath::functions::measure_async_future(#measurement_loc, async #block).await
+            }
+        }
+    } else if enable_result_logging {
         quote! {
-            hotpath::functions::measure_async(
-                concat!(module_path!(), "::", #name),
-                async #block
-            ).await
+            hotpath::functions::measure_async_log(#measurement_loc, async #block).await
         }
     } else {
         quote! {
-            let _guard = hotpath::functions::build_measurement_guard_sync(
-                concat!(module_path!(), "::", #name),
-                false,
-            );
-            #block
+            hotpath::functions::measure_async(#measurement_loc, async #block).await
         }
     };
 
     let output = quote! {
         #(#attrs)*
         #vis #sig {
-            #wrapped
+            #wrapped_body
         }
     };
 

--- a/crates/hotpath/src/lib_off.rs
+++ b/crates/hotpath/src/lib_off.rs
@@ -173,20 +173,50 @@ impl MeasurementGuard {
 }
 
 #[inline]
-pub fn measure_with_log<T: std::fmt::Debug, F: FnOnce() -> T>(
-    _name: &'static str,
-    _wrapper: bool,
+pub fn measure_sync<T, F: FnOnce() -> T>(_measurement_loc: &'static str, f: F) -> T {
+    f()
+}
+
+#[inline]
+pub fn measure_sync_log<T: std::fmt::Debug, F: FnOnce() -> T>(
+    _measurement_loc: &'static str,
     f: F,
 ) -> T {
     f()
 }
 
-pub async fn measure_with_log_async<T: std::fmt::Debug, F, Fut>(_name: &'static str, f: F) -> T
+pub async fn measure_async<T, Fut>(_measurement_loc: &'static str, fut: Fut) -> T
 where
-    F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = T>,
 {
-    f().await
+    fut.await
+}
+
+pub async fn measure_async_log<T: std::fmt::Debug, Fut>(
+    _measurement_loc: &'static str,
+    fut: Fut,
+) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    fut.await
+}
+
+pub async fn measure_async_future<T, Fut>(_measurement_loc: &'static str, fut: Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    fut.await
+}
+
+pub async fn measure_async_future_log<T: std::fmt::Debug, Fut>(
+    _measurement_loc: &'static str,
+    fut: Fut,
+) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    fut.await
 }
 
 pub struct HotpathGuard;

--- a/crates/hotpath/src/lib_on.rs
+++ b/crates/hotpath/src/lib_on.rs
@@ -29,7 +29,8 @@ pub mod hotpath_guard;
 pub(crate) mod report;
 
 pub use functions::{
-    measure_with_log, measure_with_log_async, MeasurementGuardAsync, MeasurementGuardSync,
+    measure_async, measure_async_future, measure_async_future_log, measure_async_log, measure_sync,
+    measure_sync_log, MeasurementGuardAsync, MeasurementGuardSync,
 };
 pub use hotpath_guard::{HotpathGuard, HotpathGuardBuilder};
 

--- a/crates/hotpath/src/lib_on/functions.rs
+++ b/crates/hotpath/src/lib_on/functions.rs
@@ -190,35 +190,54 @@ fn build_measurement_guard_async_with_log_bridge(
     }
 }
 
-/// Measure a sync function and log its return value.
+/// Internal helper used by `#[hotpath::measure]` for sync functions without `log = true`.
+///
+/// `measurement_loc` is the fully-qualified function path used as the metrics key.
+/// `f` is the function body closure to execute under a sync measurement guard.
+#[doc(hidden)]
+#[inline]
+#[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure)]
+pub fn measure_sync<T, F: FnOnce() -> T>(measurement_loc: &'static str, f: F) -> T {
+    let _guard = build_measurement_guard_sync(measurement_loc, false);
+    f()
+}
+
+/// Internal helper used by `#[hotpath::measure(log = true)]` for sync functions.
+///
+/// `measurement_loc` is the fully-qualified function path used as the metrics key.
+/// `f` is the function body closure; its return value is recorded in recent logs.
 #[doc(hidden)]
 #[inline]
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-pub fn measure_with_log<T: std::fmt::Debug, F: FnOnce() -> T>(
-    name: &'static str,
-    wrapper: bool,
+pub fn measure_sync_log<T: std::fmt::Debug, F: FnOnce() -> T>(
+    measurement_loc: &'static str,
     f: F,
 ) -> T {
-    let guard = build_measurement_guard_sync_with_log(name, wrapper);
+    let guard = build_measurement_guard_sync_with_log(measurement_loc, false);
     let result = f();
     guard.finish_with_result(&result);
     result
 }
 
-/// Measure an async function and log its return value.
+/// Internal helper used by `#[hotpath::measure(log = true)]` for async functions.
+///
+/// `measurement_loc` is the fully-qualified function path used as the metrics key.
+/// `fut` is the already-constructed async body future whose output is logged.
 #[doc(hidden)]
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-pub async fn measure_with_log_async<T: std::fmt::Debug, F, Fut>(name: &'static str, f: F) -> T
+pub async fn measure_async_log<T: std::fmt::Debug, Fut>(
+    measurement_loc: &'static str,
+    fut: Fut,
+) -> T
 where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = T>,
+    Fut: Future<Output = T>,
 {
     cfg_if::cfg_if! {
         if #[cfg(feature = "hotpath-alloc")] {
-            let (guard, alloc_bridge) = build_measurement_guard_async_with_log_bridge(name, false);
+            let (guard, alloc_bridge) = build_measurement_guard_async_with_log_bridge(measurement_loc, false);
             let result = crate::futures::wrapper::InstrumentedFuture::new(
-                f(),
-                name,
+                fut,
+                measurement_loc,
                 None,
                 alloc_bridge,
                 false,
@@ -227,72 +246,77 @@ where
             guard.finish_with_result(&result);
             result
         } else {
-            let guard = build_measurement_guard_async_with_log(name, false);
-            let result = f().await;
+            let guard = build_measurement_guard_async_with_log(measurement_loc, false);
+            let result = fut.await;
             guard.finish_with_result(&result);
             result
         }
     }
 }
 
-/// Measure an async function without emitting future events.
+/// Internal helper used by `#[hotpath::measure]` for async functions.
+///
+/// `measurement_loc` is the fully-qualified function path used as the metrics key.
+/// `fut` is the async body future measured for timing/allocs only.
 #[doc(hidden)]
-pub async fn measure_async<T, Fut>(name: &'static str, fut: Fut) -> T
+pub async fn measure_async<T, Fut>(measurement_loc: &'static str, fut: Fut) -> T
 where
     Fut: Future<Output = T>,
 {
     cfg_if::cfg_if! {
         if #[cfg(feature = "hotpath-alloc")] {
-            let (_guard, alloc_bridge) = build_measurement_guard_async_with_bridge(name, false);
+            let (_guard, alloc_bridge) =
+                build_measurement_guard_async_with_bridge(measurement_loc, false);
             crate::futures::wrapper::InstrumentedFuture::new(
                 fut,
-                name,
+                measurement_loc,
                 None,
                 alloc_bridge,
                 false,
             )
             .await
         } else {
-            let _guard = build_measurement_guard_async(name, false);
+            let _guard = build_measurement_guard_async(measurement_loc, false);
             fut.await
         }
     }
 }
 
-/// Measure an async function with explicit future instrumentation (`measure(future = true)`).
+/// Internal helper used by `#[hotpath::measure(future = true)]`.
+///
+/// `measurement_loc` is the fully-qualified function path used for both function
+/// measurement and visible future lifecycle events.
+/// `fut` is the async body future to instrument.
 #[doc(hidden)]
-pub async fn measure_with_future_async<T, Fut>(
-    name: &'static str,
-    future_loc: &'static str,
-    fut: Fut,
-) -> T
+pub async fn measure_async_future<T, Fut>(measurement_loc: &'static str, fut: Fut) -> T
 where
     Fut: Future<Output = T>,
 {
     crate::futures::init_futures_state();
 
-    let (_guard, alloc_bridge) = build_measurement_guard_async_with_bridge(name, false);
-    crate::futures::wrapper::InstrumentedFuture::new(fut, future_loc, None, alloc_bridge, true)
+    let (_guard, alloc_bridge) = build_measurement_guard_async_with_bridge(measurement_loc, false);
+    crate::futures::wrapper::InstrumentedFuture::new(fut, measurement_loc, None, alloc_bridge, true)
         .await
 }
 
-/// Measure an async function with explicit future instrumentation and return-value logs.
+/// Internal helper used by `#[hotpath::measure(future = true, log = true)]`.
+///
+/// `measurement_loc` is the fully-qualified function path used for function metrics
+/// and future lifecycle events.
+/// `fut` is the async body future; its output is recorded in future/function logs.
 #[doc(hidden)]
-pub async fn measure_with_future_log_async<T, Fut>(
-    name: &'static str,
-    future_loc: &'static str,
-    fut: Fut,
-) -> T
+pub async fn measure_async_future_log<T, Fut>(measurement_loc: &'static str, fut: Fut) -> T
 where
     T: std::fmt::Debug,
     Fut: Future<Output = T>,
 {
     crate::futures::init_futures_state();
 
-    let (guard, alloc_bridge) = build_measurement_guard_async_with_log_bridge(name, false);
+    let (guard, alloc_bridge) =
+        build_measurement_guard_async_with_log_bridge(measurement_loc, false);
     let result = crate::futures::wrapper::InstrumentedFutureLog::new(
         fut,
-        future_loc,
+        measurement_loc,
         None,
         alloc_bridge,
         true,


### PR DESCRIPTION
Refactor measurement macro/runtime naming and branching for consistency, including simplified measure_impl logic.