### PR TITLE
feat: Add Windows Support for Thread Monitoring

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    if: false
+    # if: false
     name: test ${{ matrix.rust }}
     runs-on: windows-latest
     timeout-minutes: 18
@@ -41,3 +41,6 @@ jobs:
       - name: Run functions tests
         run: |
           cargo test --features hotpath --test functions -- --nocapture --test-threads=1
+      - name: Run threads tests
+        run: |
+          cargo test --features hotpath --test threads -- --nocapture --test-threads=1

--- a/crates/hotpath/Cargo.toml
+++ b/crates/hotpath/Cargo.toml
@@ -97,6 +97,14 @@ hotpath-meta = { workspace = true, optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = { version = "0.6", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_ProcessStatus",
+], optional = true }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 

--- a/crates/hotpath/src/lib_on/threads.rs
+++ b/crates/hotpath/src/lib_on/threads.rs
@@ -15,6 +15,10 @@ mod collector;
 #[path = "threads/collector_linux.rs"]
 mod collector;
 
+#[cfg(target_os = "windows")]
+#[path = "threads/collector_windows.rs"]
+mod collector;
+
 pub(crate) use crate::json::ThreadMetrics;
 use crate::json::{format_bytes_signed, JsonThreadEntry, JsonThreadsList};
 use crate::output::format_bytes;
@@ -96,7 +100,7 @@ pub(crate) fn init_threads_monitoring() {
 }
 
 #[cfg_attr(feature = "hotpath-meta", hotpath_meta::measure(log = true))]
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn collector_loop(state: ThreadsStateRef, interval: Duration) {
     loop {
         match collector::collect_thread_metrics() {
@@ -163,7 +167,7 @@ fn collector_loop(state: ThreadsStateRef, interval: Duration) {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn collector_loop(_state: ThreadsStateRef, _interval: Duration) {
     // No-op on unsupported platforms - sleep forever
     loop {
@@ -172,12 +176,12 @@ fn collector_loop(_state: ThreadsStateRef, _interval: Duration) {
 }
 
 /// Get RSS from collector (platform-specific)
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn get_rss_bytes() -> Option<u64> {
     collector::get_rss_bytes()
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn get_rss_bytes() -> Option<u64> {
     None
 }

--- a/crates/hotpath/src/lib_on/threads/collector_windows.rs
+++ b/crates/hotpath/src/lib_on/threads/collector_windows.rs
@@ -1,0 +1,172 @@
+//! Windows system API thread metrics collection
+//!
+//! Implementation plan:
+//! 1. Use Toolhelp32 snapshot to iterate all threads in the current process.
+//! 2. Open each thread with THREAD_QUERY_LIMITED_INFORMATION access.
+//! 3. Use GetThreadTimes to retrieve user and kernel CPU times.
+//! 4. Use GetThreadDescription (Windows 10+) to retrieve the thread name.
+//! 5. Use GetProcessMemoryInfo for process-level RSS (Resident Set Size).
+
+use super::ThreadMetrics;
+use std::mem;
+use windows::core::PWSTR;
+use windows::Win32::Foundation::*;
+use windows::Win32::System::Diagnostics::ToolHelp::*;
+use windows::Win32::System::Memory::LocalFree;
+use windows::Win32::System::ProcessStatus::*;
+use windows::Win32::System::Threading::*;
+
+/// Collect per-thread CPU usage metrics for the current process on Windows
+pub(crate) fn collect_thread_metrics() -> Result<Vec<ThreadMetrics>, String> {
+    let mut metrics = Vec::new();
+    let pid = unsafe { GetCurrentProcessId() };
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }
+        .map_err(|e| format!("Failed to create toolhelp snapshot: {}", e))?;
+
+    let mut te = THREADENTRY32 {
+        dwSize: mem::size_of::<THREADENTRY32>() as u32,
+        ..unsafe { mem::zeroed() }
+    };
+
+    unsafe {
+        if Thread32First(snapshot, &mut te).is_ok() {
+            loop {
+                if te.th32OwnerProcessID == pid {
+                    match get_thread_info(te.th32ThreadID) {
+                        Ok(metric) => metrics.push(metric),
+                        Err(_) => {
+                            // Thread may have exited between listing and querying - this is normal
+                        }
+                    }
+                }
+                if Thread32Next(snapshot, &mut te).is_err() {
+                    break;
+                }
+            }
+        }
+        let _ = CloseHandle(snapshot);
+    }
+
+    Ok(metrics)
+}
+
+fn get_thread_info(tid: u32) -> Result<ThreadMetrics, String> {
+    unsafe {
+        let handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid)
+            .map_err(|e| format!("Failed to open thread {}: {}", tid, e))?;
+
+        let mut creation_time = FILETIME::default();
+        let mut exit_time = FILETIME::default();
+        let mut kernel_time = FILETIME::default();
+        let mut user_time = FILETIME::default();
+
+        let res = GetThreadTimes(
+            handle,
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        );
+
+        if res.is_err() {
+            let _ = CloseHandle(handle);
+            return Err(format!("GetThreadTimes failed for thread {}", tid));
+        }
+
+        let cpu_user = filetime_to_seconds(user_time);
+        let cpu_sys = filetime_to_seconds(kernel_time);
+
+        let name = get_thread_name(handle).unwrap_or_else(|| format!("thread_{}", tid));
+
+        // Windows doesn't expose a simple thread status like Linux /proc.
+        // We'll report "Running" as the default status for active threads.
+        let status = "Running ".to_string();
+        let status_code = "R".to_string();
+
+        let _ = CloseHandle(handle);
+
+        Ok(ThreadMetrics::new(
+            tid as u64,
+            name,
+            status,
+            status_code,
+            cpu_user,
+            cpu_sys,
+        ))
+    }
+}
+
+/// Convert Windows FILETIME (100-nanosecond intervals) to seconds
+fn filetime_to_seconds(ft: FILETIME) -> f64 {
+    let intervals = ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64);
+    intervals as f64 / 10_000_000.0
+}
+
+/// Retrieve thread name via GetThreadDescription (Windows 10, version 1607+)
+unsafe fn get_thread_name(handle: HANDLE) -> Option<String> {
+    let mut name_ptr = PWSTR::null();
+    if GetThreadDescription(handle, &mut name_ptr).is_ok() && !name_ptr.is_null() {
+        let name = name_ptr.to_string().ok();
+        let _ = LocalFree(HLOCAL(name_ptr.as_ptr() as *mut _));
+        name
+    } else {
+        None
+    }
+}
+
+/// Get the RSS (Working Set Size) of the current process in bytes
+pub(crate) fn get_rss_bytes() -> Option<u64> {
+    unsafe {
+        let mut pmc = PROCESS_MEMORY_COUNTERS::default();
+        if GetProcessMemoryInfo(
+            GetCurrentProcess(),
+            &mut pmc,
+            mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+        )
+        .is_ok()
+        {
+            Some(pmc.WorkingSetSize as u64)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn windows_thread_metrics_smoke_test() {
+        let metrics = collect_thread_metrics().expect("collect_thread_metrics should succeed");
+        assert!(!metrics.is_empty());
+
+        for m in &metrics {
+            assert_ne!(m.os_tid, 0, "os_tid should not be zero");
+            assert!(m.cpu_user >= 0.0);
+            assert!(m.cpu_sys >= 0.0);
+            assert!(m.cpu_total >= 0.0);
+        }
+
+        let rss = get_rss_bytes();
+        assert!(rss.is_some());
+        assert!(rss.unwrap() > 0);
+
+        // Verify metrics change over time
+        let start_total: f64 = metrics.iter().map(|m| m.cpu_total).sum();
+        
+        // Do some work
+        let mut _v = Vec::new();
+        for i in 0..10000 {
+            _v.push(i);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+        
+        let metrics2 = collect_thread_metrics().expect("second collection should succeed");
+        let end_total: f64 = metrics2.iter().map(|m| m.cpu_total).sum();
+        
+        assert!(end_total >= start_total);
+    }
+}

--- a/crates/hotpath/src/lib_on/threads/collector_windows.rs
+++ b/crates/hotpath/src/lib_on/threads/collector_windows.rs
@@ -1,90 +1,126 @@
-//! Windows system API thread metrics collection
+//! Windows-specific thread metrics collection implementation.
 //!
-//! Implementation plan:
-//! 1. Use Toolhelp32 snapshot to iterate all threads in the current process.
-//! 2. Open each thread with THREAD_QUERY_LIMITED_INFORMATION access.
-//! 3. Use GetThreadTimes to retrieve user and kernel CPU times.
-//! 4. Use GetThreadDescription (Windows 10+) to retrieve the thread name.
-//! 5. Use GetProcessMemoryInfo for process-level RSS (Resident Set Size).
+//! This module provides the Windows backend for thread monitoring, leveraging
+//! the Toolhelp32 API for thread enumeration and the `GetThreadTimes` API for
+//! CPU usage tracking. It implements robust resource management via RAII guards
+//! and adheres to idiomatic Rust patterns for Win32 interop.
 
 use super::ThreadMetrics;
 use std::mem;
-use windows::core::PWSTR;
+use windows::core::{Error, PWSTR};
 use windows::Win32::Foundation::*;
 use windows::Win32::System::Diagnostics::ToolHelp::*;
 use windows::Win32::System::Memory::LocalFree;
 use windows::Win32::System::ProcessStatus::*;
 use windows::Win32::System::Threading::*;
 
-/// Collect per-thread CPU usage metrics for the current process on Windows
+/// RAII wrapper for Win32 handles to ensure they are always closed.
+struct ScopedHandle(HANDLE);
+
+impl ScopedHandle {
+    /// Wraps a raw Win32 handle.
+    fn new(handle: HANDLE) -> Self {
+        Self(handle)
+    }
+
+    /// Returns true if the underlying handle is invalid or null.
+    fn is_invalid(&self) -> bool {
+        self.0.is_invalid() || self.0.0 == 0
+    }
+
+    /// Returns the raw handle for use with Win32 APIs.
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
+}
+
+impl Drop for ScopedHandle {
+    fn drop(&mut self) {
+        if !self.is_invalid() {
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+/// Collects CPU usage and state metrics for all threads in the current process.
+///
+/// This function captures a snapshot of all system threads and filters for those
+/// belonging to the current process. For each identified thread, it queries
+/// detailed timing and metadata.
 pub(crate) fn collect_thread_metrics() -> Result<Vec<ThreadMetrics>, String> {
     let mut metrics = Vec::new();
-    let pid = unsafe { GetCurrentProcessId() };
+    let current_pid = unsafe { GetCurrentProcessId() };
 
-    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }
-        .map_err(|e| format!("Failed to create toolhelp snapshot: {}", e))?;
+    // Capture a snapshot of all threads in the system.
+    let snapshot = unsafe {
+        CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)
+            .map(ScopedHandle::new)
+            .map_err(|e| format!("Failed to capture thread snapshot: {}", e))?
+    };
 
-    let mut te = THREADENTRY32 {
+    if snapshot.is_invalid() {
+        return Err("Thread snapshot handle is invalid".to_string());
+    }
+
+    let mut entry = THREADENTRY32 {
         dwSize: mem::size_of::<THREADENTRY32>() as u32,
         ..unsafe { mem::zeroed() }
     };
 
     unsafe {
-        if Thread32First(snapshot, &mut te).is_ok() {
+        // Iterate through the thread list in the snapshot.
+        if Thread32First(snapshot.raw(), &mut entry).is_ok() {
             loop {
-                if te.th32OwnerProcessID == pid {
-                    match get_thread_info(te.th32ThreadID) {
-                        Ok(metric) => metrics.push(metric),
-                        Err(_) => {
-                            // Thread may have exited between listing and querying - this is normal
-                        }
+                // Filter for threads belonging to the current process.
+                if entry.th32OwnerProcessID == current_pid {
+                    if let Ok(metric) = query_thread_metrics(entry.th32ThreadID) {
+                        metrics.push(metric);
                     }
                 }
-                if Thread32Next(snapshot, &mut te).is_err() {
+
+                if Thread32Next(snapshot.raw(), &mut entry).is_err() {
                     break;
                 }
             }
         }
-        let _ = CloseHandle(snapshot);
     }
 
     Ok(metrics)
 }
 
-fn get_thread_info(tid: u32) -> Result<ThreadMetrics, String> {
+/// Queries detailed metrics for a specific thread by its ID.
+fn query_thread_metrics(tid: u32) -> Result<ThreadMetrics, Error> {
     unsafe {
+        // Open the thread with minimal required permissions for metrics collection.
         let handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid)
-            .map_err(|e| format!("Failed to open thread {}: {}", tid, e))?;
+            .map(ScopedHandle::new)?;
 
         let mut creation_time = FILETIME::default();
         let mut exit_time = FILETIME::default();
         let mut kernel_time = FILETIME::default();
         let mut user_time = FILETIME::default();
 
-        let res = GetThreadTimes(
-            handle,
+        // Retrieve thread-level CPU usage (user and kernel mode times).
+        GetThreadTimes(
+            handle.raw(),
             &mut creation_time,
             &mut exit_time,
             &mut kernel_time,
             &mut user_time,
-        );
-
-        if res.is_err() {
-            let _ = CloseHandle(handle);
-            return Err(format!("GetThreadTimes failed for thread {}", tid));
-        }
+        )?;
 
         let cpu_user = filetime_to_seconds(user_time);
         let cpu_sys = filetime_to_seconds(kernel_time);
 
-        let name = get_thread_name(handle).unwrap_or_else(|| format!("thread_{}", tid));
+        // Attempt to retrieve the thread's descriptive name (Windows 10 1607+).
+        let name = fetch_thread_name(handle.raw()).unwrap_or_else(|| format!("thread_{}", tid));
 
-        // Windows doesn't expose a simple thread status like Linux /proc.
-        // We'll report "Running" as the default status for active threads.
+        // Note: Detailed thread state (Running/Waiting/Suspended) requires NtQueryInformationThread
+        // which involves undocumented APIs. We report 'Running' for all active threads.
         let status = "Running ".to_string();
         let status_code = "R".to_string();
-
-        let _ = CloseHandle(handle);
 
         Ok(ThreadMetrics::new(
             tid as u64,
@@ -97,17 +133,22 @@ fn get_thread_info(tid: u32) -> Result<ThreadMetrics, String> {
     }
 }
 
-/// Convert Windows FILETIME (100-nanosecond intervals) to seconds
+/// Converts a Windows `FILETIME` (100-nanosecond intervals) to a `f64` representing seconds.
+#[inline]
 fn filetime_to_seconds(ft: FILETIME) -> f64 {
     let intervals = ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64);
     intervals as f64 / 10_000_000.0
 }
 
-/// Retrieve thread name via GetThreadDescription (Windows 10, version 1607+)
-unsafe fn get_thread_name(handle: HANDLE) -> Option<String> {
+/// Helper to retrieve the thread name using `GetThreadDescription`.
+unsafe fn fetch_thread_name(handle: HANDLE) -> Option<String> {
     let mut name_ptr = PWSTR::null();
-    if GetThreadDescription(handle, &mut name_ptr).is_ok() && !name_ptr.is_null() {
+    if GetThreadDescription(handle, &mut name_ptr).is_ok() {
+        if name_ptr.is_null() {
+            return None;
+        }
         let name = name_ptr.to_string().ok();
+        // The memory allocated by GetThreadDescription must be freed with LocalFree.
         let _ = LocalFree(HLOCAL(name_ptr.as_ptr() as *mut _));
         name
     } else {
@@ -115,7 +156,7 @@ unsafe fn get_thread_name(handle: HANDLE) -> Option<String> {
     }
 }
 
-/// Get the RSS (Working Set Size) of the current process in bytes
+/// Retrieves the Resident Set Size (RSS) of the current process in bytes.
 pub(crate) fn get_rss_bytes() -> Option<u64> {
     unsafe {
         let mut pmc = PROCESS_MEMORY_COUNTERS::default();
@@ -139,34 +180,33 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn windows_thread_metrics_smoke_test() {
-        let metrics = collect_thread_metrics().expect("collect_thread_metrics should succeed");
-        assert!(!metrics.is_empty());
+    fn test_windows_collector_functionality() {
+        let metrics = collect_thread_metrics().expect("Should succeed in capturing metrics");
+        assert!(!metrics.is_empty(), "Captured thread list should not be empty");
 
         for m in &metrics {
-            assert_ne!(m.os_tid, 0, "os_tid should not be zero");
-            assert!(m.cpu_user >= 0.0);
-            assert!(m.cpu_sys >= 0.0);
-            assert!(m.cpu_total >= 0.0);
+            assert!(m.os_tid > 0, "TID should be positive");
+            assert!(m.cpu_total >= 0.0, "CPU time should be non-negative");
         }
 
         let rss = get_rss_bytes();
-        assert!(rss.is_some());
-        assert!(rss.unwrap() > 0);
+        assert!(rss.is_some(), "RSS should be retrievable");
+    }
 
-        // Verify metrics change over time
-        let start_total: f64 = metrics.iter().map(|m| m.cpu_total).sum();
-        
-        // Do some work
-        let mut _v = Vec::new();
-        for i in 0..10000 {
-            _v.push(i);
+    #[test]
+    fn test_cpu_time_progression() {
+        let initial = collect_thread_metrics().unwrap();
+        let initial_sum: f64 = initial.iter().map(|m| m.cpu_total).sum();
+
+        // Busy loop to consume some CPU time.
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_millis(50) {
+            std::hint::spin_loop();
         }
-        std::thread::sleep(Duration::from_millis(50));
-        
-        let metrics2 = collect_thread_metrics().expect("second collection should succeed");
-        let end_total: f64 = metrics2.iter().map(|m| m.cpu_total).sum();
-        
-        assert!(end_total >= start_total);
+
+        let subsequent = collect_thread_metrics().unwrap();
+        let subsequent_sum: f64 = subsequent.iter().map(|m| m.cpu_total).sum();
+
+        assert!(subsequent_sum >= initial_sum, "CPU time should not decrease");
     }
 }

--- a/crates/hotpath/src/lib_on/threads/collector_windows.rs
+++ b/crates/hotpath/src/lib_on/threads/collector_windows.rs
@@ -25,7 +25,7 @@ impl ScopedHandle {
 
     /// Returns true if the underlying handle is invalid or null.
     fn is_invalid(&self) -> bool {
-        self.0.is_invalid() || self.0.0 == 0
+        self.0.is_invalid() || self.0 .0 == 0
     }
 
     /// Returns the raw handle for use with Win32 APIs.
@@ -94,8 +94,8 @@ pub(crate) fn collect_thread_metrics() -> Result<Vec<ThreadMetrics>, String> {
 fn query_thread_metrics(tid: u32) -> Result<ThreadMetrics, Error> {
     unsafe {
         // Open the thread with minimal required permissions for metrics collection.
-        let handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid)
-            .map(ScopedHandle::new)?;
+        let handle =
+            OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid).map(ScopedHandle::new)?;
 
         let mut creation_time = FILETIME::default();
         let mut exit_time = FILETIME::default();
@@ -182,7 +182,10 @@ mod tests {
     #[test]
     fn test_windows_collector_functionality() {
         let metrics = collect_thread_metrics().expect("Should succeed in capturing metrics");
-        assert!(!metrics.is_empty(), "Captured thread list should not be empty");
+        assert!(
+            !metrics.is_empty(),
+            "Captured thread list should not be empty"
+        );
 
         for m in &metrics {
             assert!(m.os_tid > 0, "TID should be positive");
@@ -207,6 +210,9 @@ mod tests {
         let subsequent = collect_thread_metrics().unwrap();
         let subsequent_sum: f64 = subsequent.iter().map(|m| m.cpu_total).sum();
 
-        assert!(subsequent_sum >= initial_sum, "CPU time should not decrease");
+        assert!(
+            subsequent_sum >= initial_sum,
+            "CPU time should not decrease"
+        );
     }
 }

--- a/crates/hotpath/src/tid.rs
+++ b/crates/hotpath/src/tid.rs
@@ -44,9 +44,14 @@ fn current_tid_uncached() -> u64 {
         current_tid_macos()
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(target_os = "windows")]
     {
-        // current_tid() is only implemented for Linux and macOS");
+        current_tid_windows()
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        // current_tid() is only implemented for Linux, macOS and Windows
         0
     }
 }
@@ -64,4 +69,11 @@ fn current_tid_macos() -> u64 {
         let pthread = libc::pthread_self();
         libc::pthread_mach_thread_np(pthread) as u64
     }
+}
+
+#[cfg(target_os = "windows")]
+#[inline]
+fn current_tid_windows() -> u64 {
+    // windows v0.58 uses GetCurrentThreadId() from Win32::System::Threading
+    unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as u64 }
 }


### PR DESCRIPTION
This PR adds full Windows support to hotpath’s thread monitoring, bringing thread and RSS metrics on Windows to parity with Linux and macOS. It addresses and fixes **Add Windows Support for Thread Monitoring (#112)**.

## Summary of Changes

1. **Windows dependency in Cargo.toml**  
   - Added the `windows` crate under the Windows target in `crates/hotpath/Cargo.toml` with the following feature sets enabled:  
     - `Win32_Foundation`  
     - `Win32_System_Threading`  
     - `Win32_System_Diagnostics_ToolHelp`  
     - `Win32_System_ProcessStatus`  

2. **Windows thread collector (`collector_windows.rs`)**  
   - Introduced a Windows-specific collector that uses Win32 APIs to gather per-thread CPU usage and process memory metrics:
     - `CreateToolhelp32Snapshot` + `Thread32First` / `Thread32Next` to enumerate all threads of the current process.
     - `OpenThread(THREAD_QUERY_LIMITED_INFORMATION)` + `GetThreadTimes` to read user and kernel CPU times.
     - `GetThreadDescription` (Windows 10+) to resolve human-readable thread names where available.
     - `GetProcessMemoryInfo` to fetch process Working Set (RSS) in bytes.
   - Thread state is reported as “Running”/`"R"` for active threads, matching the existing `ThreadMetrics` interface.

3. **Integration with `threads.rs`**  
   - Enabled the thread collector on Windows by:
     - Adding the Windows-specific `collector` module behind `#[cfg(target_os = "windows")]`.
     - Including `target_os = "windows"` in the `collector_loop` and `get_rss_bytes` cfgs so that the monitoring loop and RSS reporting run on Windows as well.
   - Non-supported platforms remain a no-op as before.

4. **TID retrieval for Windows (`tid.rs`)**  
   - Implemented `current_tid()` on Windows via `GetCurrentThreadId()` from `Win32::System::Threading`.
   - Updated cfgs so that `current_tid()` is now implemented on **Linux, macOS, and Windows**, and falls back to `0` on other platforms.
