### PR TITLE
fix: feature-gated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Check utils build
         run: |
           cargo check -p hotpath --bin hotpath-utils --features=utils
+      - name: Build tests
+        run: |
+          cargo build --tests
       - name: Run CLI tests
         run: |
           cargo test -p hotpath --bin hotpath --features=tui

--- a/crates/hotpath/bin/hotpath/cmd/console/http_worker.rs
+++ b/crates/hotpath/bin/hotpath/cmd/console/http_worker.rs
@@ -169,7 +169,7 @@ impl RouteExt for Route {
             let msg = serde_json::from_str::<serde_json::Value>(&body)
                 .ok()
                 .and_then(|v| v.get("error")?.as_str().map(String::from))
-                .unwrap_or(body);
+                .unwrap_or_else(|| body.to_string());
             return DataResponse::Error(msg);
         }
 

--- a/crates/hotpath/tests/channels_asc.rs
+++ b/crates/hotpath/tests/channels_asc.rs
@@ -194,6 +194,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6772 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-asc --example basic_asc --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_asc.rs
+++ b/crates/hotpath/tests/channels_asc.rs
@@ -194,7 +194,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6772 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-asc --example basic_asc --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_crossbeam.rs
+++ b/crates/hotpath/tests/channels_crossbeam.rs
@@ -205,6 +205,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6771 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-crossbeam --example basic_crossbeam --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_crossbeam.rs
+++ b/crates/hotpath/tests/channels_crossbeam.rs
@@ -205,7 +205,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6771 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-crossbeam --example basic_crossbeam --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_ftc.rs
+++ b/crates/hotpath/tests/channels_ftc.rs
@@ -248,6 +248,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6772 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-ftc --example basic_ftc --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_ftc.rs
+++ b/crates/hotpath/tests/channels_ftc.rs
@@ -248,7 +248,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6772 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-ftc --example basic_ftc --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_std.rs
+++ b/crates/hotpath/tests/channels_std.rs
@@ -178,6 +178,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6770 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-std --example basic_std --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_std.rs
+++ b/crates/hotpath/tests/channels_std.rs
@@ -178,7 +178,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6770 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-std --example basic_std --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_tokio.rs
+++ b/crates/hotpath/tests/channels_tokio.rs
@@ -284,7 +284,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6773 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-tokio --example basic_tokio --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/channels_tokio.rs
+++ b/crates/hotpath/tests/channels_tokio.rs
@@ -284,6 +284,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6773 TEST_SLEEP_SECONDS=10 cargo run -p test-channels-tokio --example basic_tokio --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonChannelsList;

--- a/crates/hotpath/tests/functions_alloc.rs
+++ b/crates/hotpath/tests/functions_alloc.rs
@@ -210,7 +210,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonFunctionsList;
@@ -339,7 +339,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_alloc_total_bytes_not_inflated() {
         use hotpath::json::JsonReport;
@@ -391,7 +391,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_async_alloc_is_reported() {
         use hotpath::json::JsonReport;
@@ -438,7 +438,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example alloc_measure --features hotpath,hotpath-alloc
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_alloc_uninstrumented_children_tracked() {
         use hotpath::json::JsonReport;

--- a/crates/hotpath/tests/functions_alloc.rs
+++ b/crates/hotpath/tests/functions_alloc.rs
@@ -502,6 +502,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example custom_allocator --features hotpath,hotpath-alloc
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_custom_allocator_via_main_macro() {
         use hotpath::json::JsonReport;

--- a/crates/hotpath/tests/functions_alloc.rs
+++ b/crates/hotpath/tests/functions_alloc.rs
@@ -210,6 +210,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonFunctionsList;
@@ -338,6 +339,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_alloc_total_bytes_not_inflated() {
         use hotpath::json::JsonReport;
@@ -389,6 +391,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example basic --features hotpath,hotpath-alloc
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_async_alloc_is_reported() {
         use hotpath::json::JsonReport;
@@ -435,6 +438,7 @@ pub mod tests {
     }
 
     // cargo run -p test-tokio-async --example alloc_measure --features hotpath,hotpath-alloc
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_alloc_uninstrumented_children_tracked() {
         use hotpath::json::JsonReport;

--- a/crates/hotpath/tests/futures.rs
+++ b/crates/hotpath/tests/futures.rs
@@ -107,7 +107,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-futures --example basic_futures --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonFuturesList;

--- a/crates/hotpath/tests/futures.rs
+++ b/crates/hotpath/tests/futures.rs
@@ -107,6 +107,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-futures --example basic_futures --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonFuturesList;

--- a/crates/hotpath/tests/streams.rs
+++ b/crates/hotpath/tests/streams.rs
@@ -81,6 +81,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6774 TEST_SLEEP_SECONDS=10 cargo run -p test-streams --example basic_streams --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonStreamsList;

--- a/crates/hotpath/tests/streams.rs
+++ b/crates/hotpath/tests/streams.rs
@@ -81,7 +81,7 @@ pub mod tests {
     }
 
     // HOTPATH_METRICS_PORT=6774 TEST_SLEEP_SECONDS=10 cargo run -p test-streams --example basic_streams --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_data_endpoints() {
         use hotpath::json::JsonStreamsList;

--- a/crates/hotpath/tests/threads.rs
+++ b/crates/hotpath/tests/threads.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 pub mod tests {
-    use hotpath::json::JsonThreadsList;
-    use std::process::Command;
-    use std::thread::sleep;
-    use std::time::Duration;
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    use {hotpath::json::JsonThreadsList, std::thread::sleep, std::time::Duration};
 
+    use std::process::Command;
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-tokio-async --example basic --features hotpath
+    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
     #[test]
     fn test_threads_endpoint() {
         let mut child = Command::new("cargo")

--- a/crates/hotpath/tests/threads.rs
+++ b/crates/hotpath/tests/threads.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 pub mod tests {
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     use {hotpath::json::JsonThreadsList, std::thread::sleep, std::time::Duration};
 
     use std::process::Command;
     // HOTPATH_METRICS_PORT=6775 TEST_SLEEP_SECONDS=10 cargo run -p test-tokio-async --example basic --features hotpath
-    #[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
+    #[cfg(feature = "hotpath")]
     #[test]
     fn test_threads_endpoint() {
         let mut child = Command::new("cargo")


### PR DESCRIPTION
`cargo build --tests` was failing because some tests imported the `json` module, which is feature-gated. 

```rust
#[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
pub mod json;
#[cfg(any(feature = "hotpath", feature = "utils", feature = "tui"))]
pub use json::Route;
```

This change gates those tests behind the same features so they are only compiled when such features are available.