### PR TITLE
feat: abstract allocator in `hotpath-alloc`

### DIFF
--- a/crates/hotpath-macros-meta/src/lib.rs
+++ b/crates/hotpath-macros-meta/src/lib.rs
@@ -28,6 +28,8 @@ mod lib_off;
 /// * `threads_limit` - Maximum number of threads shown in the report. Overrides `limit` for threads.
 /// * `output_path` - File path for the report. Defaults to stdout. Overridden by `HOTPATH_META_OUTPUT_PATH` env var.
 /// * `report` - Comma-separated sections to include: `"functions-timing"`, `"functions-alloc"`, `"channels"`, `"streams"`, `"futures"`, `"threads"`, `"debug"`, or `"all"`. Overridden by `HOTPATH_META_REPORT` env var.
+/// * `allocator` - Optional allocator type path used when `hotpath-alloc-meta` is enabled.
+///   Defaults to `std::alloc::System`.
 ///
 /// Environment variable precedence for report output:
 /// `HOTPATH_META_LIMIT`, `HOTPATH_META_FUNCTIONS_LIMIT`,

--- a/crates/hotpath-macros-meta/src/lib_on.rs
+++ b/crates/hotpath-macros-meta/src/lib_on.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::Parser;
-use syn::{parse_macro_input, ImplItem, Item, ItemFn, Lit, LitInt, LitStr};
+use syn::{parse_macro_input, ImplItem, Item, ItemFn, Lit, LitInt, LitStr, Path};
 
 #[derive(Clone, Copy)]
 pub(crate) enum Format {
@@ -41,6 +41,8 @@ impl Format {
 /// * `threads_limit` - Maximum number of threads shown in the report. Overrides `limit` for threads.
 /// * `output_path` - File path for the report. Defaults to stdout. Overridden by `HOTPATH_META_OUTPUT_PATH` env var.
 /// * `report` - Comma-separated sections to include. Overridden by `HOTPATH_META_REPORT` env var.
+/// * `allocator` - Optional allocator type path used when `hotpath-alloc-meta` is enabled.
+///   Defaults to `std::alloc::System`.
 ///
 /// Environment variable precedence for report output:
 /// `HOTPATH_META_LIMIT`, `HOTPATH_META_FUNCTIONS_LIMIT`,
@@ -145,6 +147,7 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut threads_limit: Option<usize> = None;
     let mut output_path: Option<String> = None;
     let mut report_sections: Option<String> = None;
+    let mut allocator: Option<Path> = None;
 
     // Parse named args like: percentiles=[..], format="..", report=".."
     if !attr.is_empty() {
@@ -251,8 +254,14 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 return Ok(());
             }
 
+            if meta.path.is_ident("allocator") {
+                meta.input.parse::<syn::Token![=]>()?;
+                allocator = Some(meta.input.parse()?);
+                return Ok(());
+            }
+
             Err(meta.error(
-                "Unknown parameter. Supported: percentiles=[..], format=\"..\", limit=N, functions_limit=N, channels_limit=N, streams_limit=N, futures_limit=N, threads_limit=N, output_path=\"..\", report=\"..\"",
+                "Unknown parameter. Supported: percentiles=[..], format=\"..\", limit=N, functions_limit=N, channels_limit=N, streams_limit=N, futures_limit=N, threads_limit=N, output_path=\"..\", report=\"..\", allocator=TypePath",
             ))
         });
 
@@ -358,6 +367,17 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
     };
 
+    let allocator_path = allocator
+        .map(|path| quote! { #path })
+        .unwrap_or_else(|| quote! { ::std::alloc::System });
+
+    let allocator_item = quote! {
+        #[cfg(all(feature = "hotpath-alloc-meta", not(feature = "hotpath-alloc")))]
+        #[global_allocator]
+        static __HOTPATH_META_GLOBAL_ALLOCATOR: hotpath_meta::CountingAllocator<#allocator_path> =
+            hotpath_meta::CountingAllocator::new();
+    };
+
     let body = quote! {
         #guard_init
         #block
@@ -370,6 +390,7 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let output = quote! {
+        #allocator_item
         #vis #sig {
             #wrapped_body
         }

--- a/crates/hotpath-macros/src/lib.rs
+++ b/crates/hotpath-macros/src/lib.rs
@@ -28,6 +28,8 @@ mod lib_off;
 /// * `threads_limit` - Maximum number of threads shown in the report. Overrides `limit` for threads.
 /// * `output_path` - File path for the report. Defaults to stdout. Overridden by `HOTPATH_OUTPUT_PATH` env var.
 /// * `report` - Comma-separated sections to include: `"functions-timing"`, `"functions-alloc"`, `"channels"`, `"streams"`, `"futures"`, `"threads"`, `"debug"`, or `"all"`. Overridden by `HOTPATH_REPORT` env var.
+/// * `allocator` - Optional allocator type path used when `hotpath-alloc` is enabled.
+///   Defaults to `std::alloc::System`.
 ///
 /// Environment variable precedence for report output:
 /// `HOTPATH_LIMIT`, `HOTPATH_FUNCTIONS_LIMIT`, `HOTPATH_CHANNELS_LIMIT`,

--- a/crates/hotpath-macros/src/lib_on.rs
+++ b/crates/hotpath-macros/src/lib_on.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use std::sync::LazyLock;
 use syn::parse::Parser;
-use syn::{parse_macro_input, ImplItem, Item, ItemFn, Lit, LitInt, LitStr};
+use syn::{parse_macro_input, ImplItem, Item, ItemFn, Lit, LitInt, LitStr, Path};
 
 fn env_flag(name: &str) -> bool {
     std::env::var(name)
@@ -50,6 +50,8 @@ impl Format {
 /// * `threads_limit` - Maximum number of threads shown in the report. Overrides `limit` for threads.
 /// * `output_path` - File path for the report. Defaults to stdout. Overridden by `HOTPATH_OUTPUT_PATH` env var.
 /// * `report` - Comma-separated sections to include. Overridden by `HOTPATH_REPORT` env var.
+/// * `allocator` - Optional allocator type path used when `hotpath-alloc` is enabled.
+///   Defaults to `std::alloc::System`.
 ///
 /// Environment variable precedence for report output:
 /// `HOTPATH_LIMIT`, `HOTPATH_FUNCTIONS_LIMIT`, `HOTPATH_CHANNELS_LIMIT`,
@@ -152,6 +154,7 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut threads_limit: Option<usize> = None;
     let mut output_path: Option<String> = None;
     let mut report_sections: Option<String> = None;
+    let mut allocator: Option<Path> = None;
 
     // Parse named args like: percentiles=[..], format="..", report=".."
     if !attr.is_empty() {
@@ -258,8 +261,14 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 return Ok(());
             }
 
+            if meta.path.is_ident("allocator") {
+                meta.input.parse::<syn::Token![=]>()?;
+                allocator = Some(meta.input.parse()?);
+                return Ok(());
+            }
+
             Err(meta.error(
-                "Unknown parameter. Supported: percentiles=[..], format=\"..\", limit=N, functions_limit=N, channels_limit=N, streams_limit=N, futures_limit=N, threads_limit=N, output_path=\"..\", report=\"..\"",
+                "Unknown parameter. Supported: percentiles=[..], format=\"..\", limit=N, functions_limit=N, channels_limit=N, streams_limit=N, futures_limit=N, threads_limit=N, output_path=\"..\", report=\"..\", allocator=TypePath",
             ))
         });
 
@@ -365,6 +374,17 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
     };
 
+    let allocator_path = allocator
+        .map(|path| quote! { #path })
+        .unwrap_or_else(|| quote! { ::std::alloc::System });
+
+    let allocator_item = quote! {
+        #[cfg(feature = "hotpath-alloc")]
+        #[global_allocator]
+        static __HOTPATH_GLOBAL_ALLOCATOR: hotpath::CountingAllocator<#allocator_path> =
+            hotpath::CountingAllocator::new();
+    };
+
     let body = quote! {
         #guard_init
         #block
@@ -377,6 +397,7 @@ pub fn main_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let output = quote! {
+        #allocator_item
         #vis #sig {
             #wrapped_body
         }

--- a/crates/hotpath-meta/src/lib_on.rs
+++ b/crates/hotpath-meta/src/lib_on.rs
@@ -43,18 +43,13 @@ pub use streams::{InstrumentStream, InstrumentStreamLog};
 pub mod hotpath_guard;
 pub(crate) mod report;
 
+#[cfg(all(feature = "hotpath-alloc-meta", not(feature = "hotpath-alloc")))]
+pub use functions::alloc::allocator::CountingAllocator;
 pub use functions::{
     measure_async, measure_async_future, measure_async_future_log, measure_async_log, measure_sync,
     measure_sync_log, MeasurementGuardAsync, MeasurementGuardSync,
 };
 pub use hotpath_guard::{HotpathGuard, HotpathGuardBuilder};
-
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "hotpath-alloc-meta", not(feature = "hotpath-alloc")))] {
-        #[global_allocator]
-        static GLOBAL: functions::alloc::allocator::CountingAllocator = functions::alloc::allocator::CountingAllocator {};
-    }
-}
 
 #[must_use = "guard is dropped immediately without suspending tracking"]
 pub(crate) struct SuspendAllocTracking {

--- a/crates/hotpath-meta/src/lib_on/functions/alloc/allocator.rs
+++ b/crates/hotpath-meta/src/lib_on/functions/alloc/allocator.rs
@@ -8,23 +8,41 @@
 // - Adjusted to work with hotpath module system
 // - Split into feature-specific dispatching allocator
 
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    marker::PhantomData,
+};
 
 /// Shared global allocator that dispatches to enabled allocation tracking features
-pub(crate) struct CountingAllocator;
+pub struct CountingAllocator<A = System>(PhantomData<A>);
 
-unsafe impl GlobalAlloc for CountingAllocator {
+impl<A> CountingAllocator<A> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<A> Default for CountingAllocator<A> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+unsafe impl<A> GlobalAlloc for CountingAllocator<A>
+where
+    A: Default + GlobalAlloc,
+{
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         crate::lib_on::functions::alloc::core::track_alloc(layout.size());
 
-        unsafe { System.alloc(layout) }
+        unsafe { A::default().alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         crate::lib_on::functions::alloc::core::track_dealloc(layout.size());
 
         unsafe {
-            System.dealloc(ptr, layout);
+            A::default().dealloc(ptr, layout);
         }
     }
 }

--- a/crates/hotpath/src/lib_on.rs
+++ b/crates/hotpath/src/lib_on.rs
@@ -1,7 +1,6 @@
 #[doc(hidden)]
 pub use cfg_if::cfg_if;
 pub use hotpath_macros::{future_fn, main, measure, measure_all, skip};
-
 use std::sync::OnceLock;
 
 use crate::instant::Instant;
@@ -43,18 +42,13 @@ pub use streams::{InstrumentStream, InstrumentStreamLog};
 pub mod hotpath_guard;
 pub(crate) mod report;
 
+#[cfg(feature = "hotpath-alloc")]
+pub use functions::alloc::allocator::CountingAllocator;
 pub use functions::{
     measure_async, measure_async_future, measure_async_future_log, measure_async_log,
     measure_sync_log, MeasurementGuardAsync, MeasurementGuardSync,
 };
 pub use hotpath_guard::{HotpathGuard, HotpathGuardBuilder};
-
-cfg_if::cfg_if! {
-    if #[cfg(feature = "hotpath-alloc")] {
-        #[global_allocator]
-        static GLOBAL: functions::alloc::allocator::CountingAllocator = functions::alloc::allocator::CountingAllocator {};
-    }
-}
 
 #[must_use = "guard is dropped immediately without suspending tracking"]
 pub(crate) struct SuspendAllocTracking {

--- a/crates/hotpath/src/lib_on/functions/alloc/allocator.rs
+++ b/crates/hotpath/src/lib_on/functions/alloc/allocator.rs
@@ -8,23 +8,41 @@
 // - Adjusted to work with hotpath module system
 // - Split into feature-specific dispatching allocator
 
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    marker::PhantomData,
+};
 
 /// Shared global allocator that dispatches to enabled allocation tracking features
-pub(crate) struct CountingAllocator;
+pub struct CountingAllocator<A = System>(PhantomData<A>);
 
-unsafe impl GlobalAlloc for CountingAllocator {
+impl<A> CountingAllocator<A> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<A> Default for CountingAllocator<A> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+unsafe impl<A> GlobalAlloc for CountingAllocator<A>
+where
+    A: Default + GlobalAlloc,
+{
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         crate::lib_on::functions::alloc::core::track_alloc(layout.size());
 
-        unsafe { System.alloc(layout) }
+        unsafe { A::default().alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         crate::lib_on::functions::alloc::core::track_dealloc(layout.size());
 
         unsafe {
-            System.dealloc(ptr, layout);
+            A::default().dealloc(ptr, layout);
         }
     }
 }

--- a/crates/hotpath/tests/functions_alloc.rs
+++ b/crates/hotpath/tests/functions_alloc.rs
@@ -496,4 +496,53 @@ pub mod tests {
         );
         assert_bytes("instrumented_1kb", 1024);
     }
+
+    // cargo run -p test-tokio-async --example custom_allocator --features hotpath,hotpath-alloc
+    #[test]
+    fn test_custom_allocator_via_main_macro() {
+        use hotpath::json::JsonReport;
+
+        let output = Command::new("cargo")
+            .args([
+                "run",
+                "-p",
+                "test-tokio-async",
+                "--example",
+                "custom_allocator",
+                "--features",
+                "hotpath,hotpath-alloc",
+            ])
+            .env("HOTPATH_REPORT", "functions-alloc")
+            .env("HOTPATH_OUTPUT_FORMAT", "json")
+            .env("HOTPATH_METRICS_SERVER_OFF", "true")
+            .output()
+            .expect("Failed to execute command");
+
+        assert!(
+            output.status.success(),
+            "Process did not exit successfully.\n\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let report: JsonReport = serde_json::from_str(stdout.lines().last().expect("no output"))
+            .expect("Failed to parse JSON output");
+
+        let alloc = report
+            .functions_alloc
+            .expect("Expected functions_alloc in report");
+
+        let alloc_work = alloc
+            .data
+            .iter()
+            .find(|f| f.name == "custom_allocator::alloc_demo::alloc_work")
+            .expect("Expected custom_allocator::alloc_demo::alloc_work in alloc data");
+
+        let total_bytes = hotpath::parse_bytes(&alloc_work.total)
+            .expect("Failed to parse total bytes for custom_allocator::alloc_demo::alloc_work");
+        assert!(
+            total_bytes > 0,
+            "expected alloc_work to report allocated bytes"
+        );
+    }
 }

--- a/crates/test-tokio-async/examples/custom_allocator.rs
+++ b/crates/test-tokio-async/examples/custom_allocator.rs
@@ -1,0 +1,49 @@
+#[cfg(feature = "hotpath-alloc")]
+mod alloc_demo {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Default)]
+    pub struct TestAllocator;
+
+    unsafe impl GlobalAlloc for TestAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[hotpath::measure]
+    fn alloc_work() {
+        let buf = vec![0u8; 1024];
+        std::hint::black_box(&buf);
+    }
+
+    #[hotpath::main(allocator = TestAllocator)]
+    pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+        let before = ALLOC_CALLS.load(Ordering::Relaxed);
+        alloc_work();
+        let after = ALLOC_CALLS.load(Ordering::Relaxed);
+
+        assert!(
+            after > before,
+            "custom allocator should observe an allocation delta"
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "hotpath-alloc")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    alloc_demo::run()
+}
+
+#[cfg(not(feature = "hotpath-alloc"))]
+fn main() {}


### PR DESCRIPTION
Adds allocator selection support to `#[hotpath::main]` and `#[hotpath_meta::main]`, so downstream crates can use their favourite allocator implementing `GlobalAllocator + Default` also during allocation tracking. 

```rust
static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);

#[derive(Default)]
pub struct TestAllocator;

unsafe impl GlobalAlloc for TestAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
        unsafe { System.alloc(layout) }
    }

    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
        unsafe { System.dealloc(ptr, layout) }
    }
}

#[hotpath::measure]
fn alloc_work() {
    let buf = vec![0u8; 1024];
    std::hint::black_box(&buf);
}

#[hotpath::main(allocator = TestAllocator)]
pub fn run() -> Result<(), Box<dyn std::error::Error>> {
    let before = ALLOC_CALLS.load(Ordering::Relaxed);
    alloc_work();
    let after = ALLOC_CALLS.load(Ordering::Relaxed);

    assert!(
        after > before,
        "custom allocator should observe an allocation delta"
    );

    Ok(())
}
```
What this enables:

- By default, #[hotpath::main] uses `std::alloc::System`
- Users can pass a custom allocator type path with `allocator = ...` via short name (if type is imported in scope) or fully qualified paths

If the downstream crate already declares its own #[global_allocator], that declaration must be disabled when hotpath alloc mode is enabled, since Rust allows only one global allocator per binary
Typical pattern:

```rust
#[cfg(not(feature = "feature-enabling-hotpath-alloc"))]
#[global_allocator]
static GLOBAL: Jemalloc = Jemalloc;

// ...

#[hotpath::main(allocator = Jemalloc)]
fn main() { ... }
```