### PR TITLE
perf: Use custom Instant implementation on macos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,14 @@ cargo run --example benchmark_noop --features hotpath --release
 cargo run --example benchmark_alloc --features='hotpath,hotpath-alloc' --release
 ```
 
+#### Instant
+
+`hotpath` measures time with a custom `Instant` (`mach_absolute_time` on macOS, `quanta` on Linux) instead of `std::time::Instant`. This benchmark compares the `now()` call overhead of both clocks:
+
+```bash
+cargo run -p test-tokio-async --example benchmark_instant --features hotpath --release
+```
+
 #### Mutexes and RwLocks
 
 RwLock examples run a write loop followed by a read loop.

--- a/crates/hotpath/src/instant.rs
+++ b/crates/hotpath/src/instant.rs
@@ -1,5 +1,72 @@
 #[cfg(target_os = "linux")]
-pub(crate) type Instant = quanta::Instant;
+pub type Instant = quanta::Instant;
 
-#[cfg(not(target_os = "linux"))]
-pub(crate) type Instant = std::time::Instant;
+#[cfg(target_os = "macos")]
+pub type Instant = mach_instant::Instant;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub type Instant = std::time::Instant;
+
+/// Thin wrapper over `mach_absolute_time`. On macOS `std::time::Instant`
+/// goes through `clock_gettime(CLOCK_UPTIME_RAW)` (~25ns per call), while
+/// reading the counter directly costs ~7ns with the same resolution.
+/// Tick-to-nanosecond conversion uses the exact `mach_timebase_info` ratio.
+#[cfg(target_os = "macos")]
+mod mach_instant {
+    use std::sync::OnceLock;
+    use std::time::Duration;
+
+    #[repr(C)]
+    struct MachTimebaseInfo {
+        numer: u32,
+        denom: u32,
+    }
+
+    extern "C" {
+        fn mach_absolute_time() -> u64;
+        fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc::c_int;
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Instant(u64);
+
+    #[inline]
+    fn timebase() -> (u64, u64) {
+        static TIMEBASE: OnceLock<(u64, u64)> = OnceLock::new();
+        *TIMEBASE.get_or_init(|| {
+            let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+            let ret = unsafe { mach_timebase_info(&mut info) };
+            assert_eq!(ret, libc::KERN_SUCCESS, "mach_timebase_info failed");
+            (u64::from(info.numer), u64::from(info.denom))
+        })
+    }
+
+    #[inline]
+    fn ticks_to_ns(ticks: u64) -> u64 {
+        let (numer, denom) = timebase();
+        if numer == denom {
+            return ticks;
+        }
+        match ticks.checked_mul(numer) {
+            Some(scaled) => scaled / denom,
+            None => ((ticks as u128 * numer as u128) / denom as u128) as u64,
+        }
+    }
+
+    impl Instant {
+        #[inline]
+        pub fn now() -> Self {
+            Self(unsafe { mach_absolute_time() })
+        }
+
+        #[inline]
+        pub fn duration_since(&self, earlier: Instant) -> Duration {
+            Duration::from_nanos(ticks_to_ns(self.0.saturating_sub(earlier.0)))
+        }
+
+        #[inline]
+        pub fn elapsed(&self) -> Duration {
+            Instant::now().duration_since(*self)
+        }
+    }
+}

--- a/crates/test-tokio-async/examples/benchmark_instant.rs
+++ b/crates/test-tokio-async/examples/benchmark_instant.rs
@@ -1,0 +1,25 @@
+use std::time::Instant as StdInstant;
+
+use hotpath::instant::Instant;
+
+fn main() {
+    let runs: u32 = std::env::var("HOTPATH_BENCH_RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000_000);
+
+    let start = StdInstant::now();
+    for _ in 0..runs {
+        std::hint::black_box(Instant::now());
+    }
+    let custom_ns = start.elapsed().as_nanos() as f64 / f64::from(runs);
+
+    let start = StdInstant::now();
+    for _ in 0..runs {
+        std::hint::black_box(StdInstant::now());
+    }
+    let std_ns = start.elapsed().as_nanos() as f64 / f64::from(runs);
+
+    println!("custom Instant::now(): {custom_ns:.1} ns/call");
+    println!("std    Instant::now(): {std_ns:.1} ns/call");
+}


### PR DESCRIPTION
```
custom Instant::now(): 7.1 ns/call
std    Instant::now(): 16.3 ns/call
```