### PR TITLE
feat!: channel macro default wrap mode

### DIFF
--- a/crates/hotpath/bin/hotpath/cmd/console/app.rs
+++ b/crates/hotpath/bin/hotpath/cmd/console/app.rs
@@ -294,13 +294,11 @@ impl App {
     pub(crate) fn new(metrics_host: &str, metrics_port: u16, refresh_interval_ms: u64) -> Self {
         let (request_tx, request_rx) = hotpath::channel!(
             crossbeam_channel::unbounded::<DataRequest>(),
-            wrap = true,
             label = "tui_requests",
             log = true
         );
         let (event_tx, event_rx) = hotpath::channel!(
             crossbeam_channel::unbounded::<AppEvent>(),
-            wrap = true,
             label = "tui_events",
             log = true
         );

--- a/crates/hotpath/bin/hotpath/cmd/console/demo.rs
+++ b/crates/hotpath/bin/hotpath/cmd/console/demo.rs
@@ -19,11 +19,7 @@ fn spawn_channels() {
     // Wrap channel: tracks exact send->receive latency. The consumer outpaces the
     // producer, so the bounded channel stays near empty and each message is processed
     // as soon as it arrives - a healthy channel that keeps up with its load.
-    let (tx, rx) = hotpath::channel!(
-        crossbeam_channel::bounded::<u64>(8),
-        wrap = true,
-        label = "demo-jobs"
-    );
+    let (tx, rx) = hotpath::channel!(crossbeam_channel::bounded::<u64>(8), label = "demo-jobs");
 
     thread::spawn(move || {
         let mut i = 0u64;
@@ -47,7 +43,6 @@ fn spawn_std_channel() {
     // self-tracked queue depth climbs to the bound.
     let (tx, rx) = hotpath::channel!(
         std::sync::mpsc::sync_channel::<u64>(8),
-        wrap = true,
         capacity = 8,
         label = "demo-std-jobs"
     );

--- a/crates/hotpath/src/lib_on.rs
+++ b/crates/hotpath/src/lib_on.rs
@@ -40,7 +40,8 @@ pub mod tokio_runtime;
 pub mod functions;
 
 pub use channels::{
-    InstrumentChannel, InstrumentChannelLog, InstrumentChannelWrap, InstrumentChannelWrapLog,
+    InstrumentChannelProxy, InstrumentChannelProxyLog, InstrumentChannelWrap,
+    InstrumentChannelWrapLog,
 };
 pub use futures::{InstrumentFuture, InstrumentFutureLog};
 pub use mutexes::InstrumentMutex;

--- a/crates/hotpath/src/lib_on/channels.rs
+++ b/crates/hotpath/src/lib_on/channels.rs
@@ -692,7 +692,7 @@ pub(crate) fn extract_filename(path: &str) -> String {
 ///
 /// This trait is not intended for direct use. Use the `channel!` macro instead.
 #[doc(hidden)]
-pub trait InstrumentChannel {
+pub trait InstrumentChannelProxy {
     type Output;
     fn instrument(
         self,
@@ -706,7 +706,7 @@ pub trait InstrumentChannel {
 ///
 /// This trait is not intended for direct use. Use the `channel!` macro with `log = true` instead.
 #[doc(hidden)]
-pub trait InstrumentChannelLog {
+pub trait InstrumentChannelProxyLog {
     type Output;
     fn instrument_log(
         self,
@@ -720,8 +720,12 @@ pub trait InstrumentChannelLog {
 ///
 /// Returns wrapper types (`hotpath::wrap::<backend>::{Sender, Receiver}`) instead of
 /// the original channel types, so queue depth is measured exactly with no forwarder.
-/// Not intended for direct use. Use the `channel!` macro with `wrap = true` instead.
+/// This is the default mode of the `channel!` macro; not intended for direct use.
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "channel type `{Self}` cannot be instrumented by the default `channel!` mode",
+    note = "this backend is forwarder-only; pass `proxy = true`, e.g. `channel!(expr, proxy = true)`"
+)]
 pub trait InstrumentChannelWrap {
     type Output;
     fn instrument_wrap(
@@ -735,8 +739,12 @@ pub trait InstrumentChannelWrap {
 /// Trait for instrumenting channels by wrapping their endpoints, with message logging.
 ///
 /// This trait is not intended for direct use. Use the `channel!` macro with
-/// `wrap = true, log = true` instead.
+/// `log = true`.
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "channel type `{Self}` cannot be instrumented by the default `channel!` mode",
+    note = "this backend is forwarder-only; pass `proxy = true`, e.g. `channel!(expr, proxy = true, log = true)`"
+)]
 pub trait InstrumentChannelWrapLog {
     type Output;
     fn instrument_wrap_log(
@@ -757,32 +765,41 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Instrument a channel creation to wrap it with debugging proxies.
+/// Instrument a channel creation for profiling.
 ///
-/// Optional parameters: `label`, `log = true`, `capacity` (in any order).
-/// `capacity` is required for `futures_channel::mpsc` bounded channels.
+/// By default the macro **wraps the endpoints** (`wrap` mode): it returns
+/// `hotpath::wrap::<backend>::{Sender, Receiver}` instead of the raw channel types and
+/// measures exact queue depth plus send->receive latency, with no forwarder task.
+///
+/// Optional parameters: `label`, `log = true`, `capacity`, `proxy = true` (in any order).
 /// `log = true` requires `Debug` on the message type.
 ///
-/// # `wrap = true`
+/// # Default (wrap) mode
 ///
 /// The channel expression **must be constructed inline**, e.g.
-/// `channel!(crossbeam_channel::unbounded::<T>(), wrap = true)`. The wrapper rebuilds
-/// the inner channel (to carry a per-message id) and discards the one you pass in, so
-/// any endpoint cloned before wrapping is orphaned and its messages are silently
-/// dropped. Clone the returned wrapper endpoints instead.
+/// `channel!(crossbeam_channel::unbounded::<T>())`. The wrapper rebuilds the inner channel
+/// (to carry a per-message id) and discards the one you pass in, so any endpoint cloned
+/// before wrapping is orphaned and its messages are silently dropped. Clone the returned
+/// wrapper endpoints instead.
 ///
-/// Bounded `std::sync::mpsc` wrappers (`sync_channel`) cannot recover their capacity
-/// from the endpoint, so `capacity = N` is required, e.g.
-/// `channel!(std::sync::mpsc::sync_channel::<T>(100), wrap = true, capacity = 100)`.
-/// Unbounded std and crossbeam wrappers need no `capacity`.
+/// Bounded `std::sync::mpsc` (`sync_channel`) cannot recover its capacity from the
+/// endpoint, so `capacity = N` is required, e.g.
+/// `channel!(std::sync::mpsc::sync_channel::<T>(100), capacity = 100)`. **The value must
+/// match the `sync_channel(N)` argument** - wrap mode rebuilds the inner channel from
+/// `capacity`, so a mismatch silently changes backpressure (and only in profiled builds,
+/// since with `hotpath` off `channel!` returns your original channel untouched). std
+/// exposes no capacity accessor, so keep the two numbers equal. Unbounded std, crossbeam,
+/// flume, tokio and async-channel wrappers recover the bound from the endpoint and need no
+/// `capacity`.
 ///
-/// **The `capacity` you pass must match the `sync_channel(N)` argument.** Wrap mode
-/// rebuilds the inner channel from `capacity` and discards the one you constructed, so a
-/// mismatch (e.g. `sync_channel(100)` with `capacity = 1`) silently builds a different
-/// bounded channel - and only in profiled builds: with `hotpath` off, `channel!` returns
-/// your original `sync_channel(100)` untouched. The result is different backpressure (and
-/// potentially a deadlock) that appears only when profiling. There is no way to verify
-/// this for you, because std exposes no capacity accessor - keep the two numbers equal.
+/// # `proxy = true` (forwarder mode)
+///
+/// Passing `proxy = true` selects the forwarder-based mode: the original endpoint types are
+/// preserved (type-transparent) and a background task/thread relays every message through a
+/// second channel. This is the only mode available for backends without a wrap
+/// implementation (`futures_channel`, `tokio::sync::oneshot`); using them without
+/// `proxy = true` is a compile error that points you here. `capacity` is required for
+/// `futures_channel::mpsc` bounded channels.
 ///
 /// # Examples
 ///
@@ -798,380 +815,49 @@ cfg_if::cfg_if! {
 /// ```
 #[macro_export]
 macro_rules! channel {
-    // Wrap mode (`wrap = true`) returns instrumented endpoint wrappers
-    // (`hotpath::wrap::<backend>::{Sender, Receiver}`) for exact queue tracking.
-    // `wrap`, `label`, and `log` may appear in any order.
-    ($expr:expr, wrap = true) => {{
+    // Default: wrap mode. `channel!(expr)` -> endpoint-wrapping instrumentation.
+    ($expr:expr) => {{
         const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
         $crate::InstrumentChannelWrap::instrument_wrap($expr, CHANNEL_ID, None, None)
     }};
 
-    ($expr:expr, wrap = true, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrap::instrument_wrap(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, wrap = true, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($expr, CHANNEL_ID, None, None)
-    }};
-
-    ($expr:expr, wrap = true, label = $label:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, wrap = true, log = true, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    // Wrap mode with explicit `capacity` (required for bounded `std::sync::mpsc`
-    // wrappers, which cannot recover their capacity from the endpoint).
-    ($expr:expr, wrap = true, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrap::instrument_wrap($expr, CHANNEL_ID, None, Some($capacity))
-    }};
-
-    ($expr:expr, capacity = $capacity:expr, wrap = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrap::instrument_wrap($expr, CHANNEL_ID, None, Some($capacity))
-    }};
-
-    ($expr:expr, wrap = true, capacity = $capacity:expr, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrap::instrument_wrap(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, wrap = true, label = $label:expr, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrap::instrument_wrap(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, wrap = true, capacity = $capacity:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            None,
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, wrap = true, log = true, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            None,
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, wrap = true, capacity = $capacity:expr, label = $label:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, wrap = true, label = $label:expr, capacity = $capacity:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, label = $label:expr, wrap = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrap::instrument_wrap(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, log = true, wrap = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($expr, CHANNEL_ID, None, None)
-    }};
-
-    ($expr:expr, label = $label:expr, wrap = true, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, log = true, wrap = true, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, label = $label:expr, log = true, wrap = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, log = true, label = $label:expr, wrap = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannel::instrument($expr, CHANNEL_ID, None, None)
-    }};
-
-    ($expr:expr, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannel::instrument($expr, CHANNEL_ID, Some($label.to_string()), None)
-    }};
-
-    ($expr:expr, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannel::instrument($expr, CHANNEL_ID, None, Some($capacity))
-    }};
-
-    ($expr:expr, label = $label:expr, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannel::instrument(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, capacity = $capacity:expr, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannel::instrument(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    // Variants with log = true
-    ($expr:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelLog::instrument_log($expr, CHANNEL_ID, None, None)
-    }};
-
-    ($expr:expr, label = $label:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, log = true, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            None,
-        )
-    }};
-
-    ($expr:expr, capacity = $capacity:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log($expr, CHANNEL_ID, None, Some($capacity))
-    }};
-
-    ($expr:expr, log = true, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log($expr, CHANNEL_ID, None, Some($capacity))
-    }};
-
-    ($expr:expr, label = $label:expr, capacity = $capacity:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, label = $label:expr, log = true, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, capacity = $capacity:expr, label = $label:expr, log = true) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, capacity = $capacity:expr, log = true, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, log = true, label = $label:expr, capacity = $capacity:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    ($expr:expr, log = true, capacity = $capacity:expr, label = $label:expr) => {{
-        const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        const _: usize = $capacity;
-        $crate::InstrumentChannelLog::instrument_log(
-            $expr,
-            CHANNEL_ID,
-            Some($label.to_string()),
-            Some($capacity),
-        )
-    }};
-
-    // Order-independent muncher for wrap-mode arguments. Accumulates `label`, `capacity`
-    // and `log` in any order (the explicit arms above cover the common no-capacity
-    // orders; this handles the rest, notably bounded-std `capacity` permutations).
-    (@wrap_munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $wrap:tt ;) => {
-        $crate::channel!(@wrap_dispatch $id, $e ; $lbl $cap $log $wrap)
-    };
-    (@wrap_munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $wrap:tt ; wrap = true $(, $($r:tt)*)?) => {
-        $crate::channel!(@wrap_munch $id, $e ; $lbl $cap $log [wrap] ; $($($r)*)?)
-    };
-    (@wrap_munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $wrap:tt ; label = $l:expr $(, $($r:tt)*)?) => {
-        $crate::channel!(@wrap_munch $id, $e ; [$l] $cap $log $wrap ; $($($r)*)?)
-    };
-    (@wrap_munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $wrap:tt ; capacity = $c:expr $(, $($r:tt)*)?) => {
-        $crate::channel!(@wrap_munch $id, $e ; $lbl [$c] $log $wrap ; $($($r)*)?)
-    };
-    (@wrap_munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $wrap:tt ; log = true $(, $($r:tt)*)?) => {
-        $crate::channel!(@wrap_munch $id, $e ; $lbl $cap [log] $wrap ; $($($r)*)?)
-    };
-
-    (@wrap_dispatch $id:ident, $e:expr ; [$l:expr] [$c:expr] [log] [wrap]) => {
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($e, $id, Some($l.to_string()), Some($c))
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [$l:expr] [$c:expr] [nolog] [wrap]) => {
-        $crate::InstrumentChannelWrap::instrument_wrap($e, $id, Some($l.to_string()), Some($c))
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [] [$c:expr] [log] [wrap]) => {
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($e, $id, None, Some($c))
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [] [$c:expr] [nolog] [wrap]) => {
-        $crate::InstrumentChannelWrap::instrument_wrap($e, $id, None, Some($c))
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [$l:expr] [] [log] [wrap]) => {
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($e, $id, Some($l.to_string()), None)
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [$l:expr] [] [nolog] [wrap]) => {
-        $crate::InstrumentChannelWrap::instrument_wrap($e, $id, Some($l.to_string()), None)
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [] [] [log] [wrap]) => {
-        $crate::InstrumentChannelWrapLog::instrument_wrap_log($e, $id, None, None)
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; [] [] [nolog] [wrap]) => {
-        $crate::InstrumentChannelWrap::instrument_wrap($e, $id, None, None)
-    };
-    (@wrap_dispatch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt [nowrap]) => {
-        compile_error!("channel!: unsupported argument combination")
-    };
-
-    // Fallback entry for `wrap = true` calls whose argument order is not covered by an
-    // explicit arm above. `CHANNEL_ID` is captured once here at the call site and
-    // threaded through the muncher so `file!()`/`line!()` resolve to the user's location.
+    // Any argument list is parsed order-independently by the muncher below. Slots are
+    // `label capacity log proxy`; `label`/`capacity` are stored as ready-to-use `Option`
+    // tokens so the dispatch only branches on `log` x `proxy`. `CHANNEL_ID` is captured
+    // once here so `file!()`/`line!()` resolve to the user's call site.
     ($expr:expr, $($rest:tt)*) => {{
         const CHANNEL_ID: &'static str = concat!(file!(), ":", line!());
-        $crate::channel!(@wrap_munch CHANNEL_ID, $expr ; [] [] [nolog] [nowrap] ; $($rest)*)
+        $crate::channel!(@munch CHANNEL_ID, $expr ; (None) (None) [nolog] [wrap] ; $($rest)*)
     }};
+
+    (@munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $proxy:tt ;) => {
+        $crate::channel!(@dispatch $id, $e ; $lbl $cap $log $proxy)
+    };
+    (@munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $proxy:tt ; proxy = true $(, $($r:tt)*)?) => {
+        $crate::channel!(@munch $id, $e ; $lbl $cap $log [proxy] ; $($($r)*)?)
+    };
+    (@munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $proxy:tt ; label = $l:expr $(, $($r:tt)*)?) => {
+        $crate::channel!(@munch $id, $e ; (Some($l.to_string())) $cap $log $proxy ; $($($r)*)?)
+    };
+    (@munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $proxy:tt ; capacity = $c:expr $(, $($r:tt)*)?) => {
+        $crate::channel!(@munch $id, $e ; $lbl (Some($c)) $log $proxy ; $($($r)*)?)
+    };
+    (@munch $id:ident, $e:expr ; $lbl:tt $cap:tt $log:tt $proxy:tt ; log = true $(, $($r:tt)*)?) => {
+        $crate::channel!(@munch $id, $e ; $lbl $cap [log] $proxy ; $($($r)*)?)
+    };
+
+    (@dispatch $id:ident, $e:expr ; $lbl:tt $cap:tt [nolog] [wrap]) => {
+        $crate::InstrumentChannelWrap::instrument_wrap($e, $id, $lbl, $cap)
+    };
+    (@dispatch $id:ident, $e:expr ; $lbl:tt $cap:tt [log] [wrap]) => {
+        $crate::InstrumentChannelWrapLog::instrument_wrap_log($e, $id, $lbl, $cap)
+    };
+    (@dispatch $id:ident, $e:expr ; $lbl:tt $cap:tt [nolog] [proxy]) => {
+        $crate::InstrumentChannelProxy::instrument($e, $id, $lbl, $cap)
+    };
+    (@dispatch $id:ident, $e:expr ; $lbl:tt $cap:tt [log] [proxy]) => {
+        $crate::InstrumentChannelProxyLog::instrument_log($e, $id, $lbl, $cap)
+    };
 }
 
 /// Compare two channel stats for sorting.

--- a/crates/hotpath/src/lib_on/channels/wrapper/asc.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/asc.rs
@@ -158,9 +158,9 @@ pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
+impl<T: Send + 'static> InstrumentChannelProxy for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument(
         self,
@@ -177,9 +177,9 @@ impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog for (Sender<T>, Receiver<T>) {
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument_log(
         self,

--- a/crates/hotpath/src/lib_on/channels/wrapper/asc_wrap.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/asc_wrap.rs
@@ -1,4 +1,4 @@
-//! Endpoint-wrapping async-channel instrumentation (`channel!(..., wrap = true)`).
+//! Endpoint-wrapping async-channel instrumentation for the `channel!` macro.
 //!
 //! Wraps the `Sender`/`Receiver` endpoints directly (unlike the forwarder-proxy in
 //! [`crate::channels::wrapper::asc`]): no extra task or proxy channel, so send/recv hit

--- a/crates/hotpath/src/lib_on/channels/wrapper/crossbeam.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/crossbeam.rs
@@ -130,9 +130,9 @@ pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>)
 {
     type Output = (crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>);
@@ -151,9 +151,9 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>)
 {
     type Output = (crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>);

--- a/crates/hotpath/src/lib_on/channels/wrapper/crossbeam_wrap.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/crossbeam_wrap.rs
@@ -1,4 +1,4 @@
-//! Endpoint-wrapping crossbeam channel instrumentation (`channel!(..., wrap = true)`).
+//! Endpoint-wrapping crossbeam channel instrumentation for the `channel!` macro.
 //!
 //! Wraps the `Sender`/`Receiver` endpoints directly (unlike the forwarder-proxy in
 //! [`crate::channels::wrapper::crossbeam`]): no extra thread or proxy channel, so

--- a/crates/hotpath/src/lib_on/channels/wrapper/flume.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/flume.rs
@@ -132,9 +132,9 @@ pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
+impl<T: Send + 'static> InstrumentChannelProxy for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument(
         self,
@@ -149,9 +149,9 @@ impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog for (Sender<T>, Receiver<T>) {
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument_log(
         self,

--- a/crates/hotpath/src/lib_on/channels/wrapper/flume_wrap.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/flume_wrap.rs
@@ -1,4 +1,4 @@
-//! Endpoint-wrapping flume channel instrumentation (`channel!(..., wrap = true)`).
+//! Endpoint-wrapping flume channel instrumentation for the `channel!` macro.
 //!
 //! Wraps the `Sender`/`Receiver` endpoints directly (unlike the forwarder-proxy in
 //! [`crate::channels::wrapper::flume`]): no extra task or proxy channel, so send/recv

--- a/crates/hotpath/src/lib_on/channels/wrapper/ftc.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/ftc.rs
@@ -225,9 +225,9 @@ pub(crate) fn wrap_oneshot_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (
         futures_channel::mpsc::Sender<T>,
         futures_channel::mpsc::Receiver<T>,
@@ -250,7 +250,7 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (
         futures_channel::mpsc::UnboundedSender<T>,
         futures_channel::mpsc::UnboundedReceiver<T>,
@@ -270,7 +270,7 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (
         futures_channel::oneshot::Sender<T>,
         futures_channel::oneshot::Receiver<T>,
@@ -290,9 +290,9 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (
         futures_channel::mpsc::Sender<T>,
         futures_channel::mpsc::Receiver<T>,
@@ -315,7 +315,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
     }
 }
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (
         futures_channel::mpsc::UnboundedSender<T>,
         futures_channel::mpsc::UnboundedReceiver<T>,
@@ -335,7 +335,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
     }
 }
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (
         futures_channel::oneshot::Sender<T>,
         futures_channel::oneshot::Receiver<T>,

--- a/crates/hotpath/src/lib_on/channels/wrapper/std.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/std.rs
@@ -129,9 +129,9 @@ pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (std::sync::mpsc::Sender<T>, std::sync::mpsc::Receiver<T>)
 {
     type Output = (std::sync::mpsc::Sender<T>, std::sync::mpsc::Receiver<T>);
@@ -145,7 +145,7 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-impl<T: Send + 'static> InstrumentChannel
+impl<T: Send + 'static> InstrumentChannelProxy
     for (std::sync::mpsc::SyncSender<T>, std::sync::mpsc::Receiver<T>)
 {
     type Output = (std::sync::mpsc::SyncSender<T>, std::sync::mpsc::Receiver<T>);
@@ -162,9 +162,9 @@ impl<T: Send + 'static> InstrumentChannel
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (std::sync::mpsc::Sender<T>, std::sync::mpsc::Receiver<T>)
 {
     type Output = (std::sync::mpsc::Sender<T>, std::sync::mpsc::Receiver<T>);
@@ -178,7 +178,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
     }
 }
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (std::sync::mpsc::SyncSender<T>, std::sync::mpsc::Receiver<T>)
 {
     type Output = (std::sync::mpsc::SyncSender<T>, std::sync::mpsc::Receiver<T>);

--- a/crates/hotpath/src/lib_on/channels/wrapper/std_wrap.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/std_wrap.rs
@@ -1,4 +1,4 @@
-//! Endpoint-wrapping `std::sync::mpsc` channel instrumentation (`channel!(..., wrap = true)`).
+//! Endpoint-wrapping `std::sync::mpsc` channel instrumentation for the `channel!` macro.
 //!
 //! Wraps the `Sender`/`SyncSender`/`Receiver` endpoints directly (unlike the
 //! forwarder-proxy in [`crate::channels::wrapper::std`]): no extra thread or proxy
@@ -389,7 +389,7 @@ fn build_bounded<T>(
 
 fn require_capacity(capacity: Option<usize>) -> usize {
     capacity.unwrap_or_else(|| {
-        panic!("bounded std::sync::mpsc wrap requires `capacity = N` (std exposes no capacity accessor); it must match the sync_channel(N) argument, e.g. channel!(mpsc::sync_channel::<T>(100), wrap = true, capacity = 100)")
+        panic!("bounded std::sync::mpsc wrap requires `capacity = N` (std exposes no capacity accessor); it must match the sync_channel(N) argument, e.g. channel!(mpsc::sync_channel::<T>(100), capacity = 100)")
     })
 }
 

--- a/crates/hotpath/src/lib_on/channels/wrapper/tokio.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/tokio.rs
@@ -237,9 +237,9 @@ pub(crate) fn wrap_oneshot_log<T: Send + std::fmt::Debug + 'static>(
     })
 }
 
-use crate::channels::InstrumentChannel;
+use crate::channels::InstrumentChannelProxy;
 
-impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
+impl<T: Send + 'static> InstrumentChannelProxy for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument(
         self,
@@ -251,7 +251,7 @@ impl<T: Send + 'static> InstrumentChannel for (Sender<T>, Receiver<T>) {
     }
 }
 
-impl<T: Send + 'static> InstrumentChannel for (UnboundedSender<T>, UnboundedReceiver<T>) {
+impl<T: Send + 'static> InstrumentChannelProxy for (UnboundedSender<T>, UnboundedReceiver<T>) {
     type Output = (UnboundedSender<T>, UnboundedReceiver<T>);
     fn instrument(
         self,
@@ -263,7 +263,7 @@ impl<T: Send + 'static> InstrumentChannel for (UnboundedSender<T>, UnboundedRece
     }
 }
 
-impl<T: Send + 'static> InstrumentChannel for (oneshot::Sender<T>, oneshot::Receiver<T>) {
+impl<T: Send + 'static> InstrumentChannelProxy for (oneshot::Sender<T>, oneshot::Receiver<T>) {
     type Output = (oneshot::Sender<T>, oneshot::Receiver<T>);
     fn instrument(
         self,
@@ -275,9 +275,9 @@ impl<T: Send + 'static> InstrumentChannel for (oneshot::Sender<T>, oneshot::Rece
     }
 }
 
-use crate::channels::InstrumentChannelLog;
+use crate::channels::InstrumentChannelProxyLog;
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog for (Sender<T>, Receiver<T>) {
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog for (Sender<T>, Receiver<T>) {
     type Output = (Sender<T>, Receiver<T>);
     fn instrument_log(
         self,
@@ -289,7 +289,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog for (Sender<T>, R
     }
 }
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (UnboundedSender<T>, UnboundedReceiver<T>)
 {
     type Output = (UnboundedSender<T>, UnboundedReceiver<T>);
@@ -303,7 +303,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
     }
 }
 
-impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelLog
+impl<T: Send + std::fmt::Debug + 'static> InstrumentChannelProxyLog
     for (oneshot::Sender<T>, oneshot::Receiver<T>)
 {
     type Output = (oneshot::Sender<T>, oneshot::Receiver<T>);

--- a/crates/hotpath/src/lib_on/channels/wrapper/tokio_wrap.rs
+++ b/crates/hotpath/src/lib_on/channels/wrapper/tokio_wrap.rs
@@ -1,4 +1,4 @@
-//! Endpoint-wrapping Tokio `mpsc` channel instrumentation (`channel!(..., wrap = true)`).
+//! Endpoint-wrapping Tokio `mpsc` channel instrumentation for the `channel!` macro.
 //!
 //! Wraps the `Sender`/`Receiver` endpoints directly, unlike the forwarder-proxy in
 //! [`crate::channels::wrapper::tokio`], which spawns a background task that relays every

--- a/crates/hotpath/tests/channels_ftc.rs
+++ b/crates/hotpath/tests/channels_ftc.rs
@@ -172,9 +172,9 @@ pub mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         let sep = path_sep();
-        let iter_57 = format!("examples{sep}iter_ftc.rs:57");
-        let iter_57_2 = format!("examples{sep}iter_ftc.rs:57-2");
-        let iter_57_3 = format!("examples{sep}iter_ftc.rs:57-3");
+        let iter_57 = format!("examples{sep}iter_ftc.rs:60");
+        let iter_57_2 = format!("examples{sep}iter_ftc.rs:60-2");
+        let iter_57_3 = format!("examples{sep}iter_ftc.rs:60-3");
         let all_expected = [
             "Actor 1",
             "Actor 1-2",

--- a/crates/hotpath/tests/channels_std_wrap.rs
+++ b/crates/hotpath/tests/channels_std_wrap.rs
@@ -43,8 +43,7 @@ pub mod tests {
     }
 
     // Bounded-std wrap requires `capacity`, which the macro accepts in any argument
-    // position. Every order (including label/log before or after `wrap = true`) must
-    // compile and register a wrapped channel.
+    // position. Every order of `capacity`/`label`/`log` must compile and register a wrapped channel.
     //
     // cargo run -p test-channels-std --example wrap_arg_orders_std --features hotpath
     #[cfg(feature = "hotpath")]

--- a/crates/test-channels-asc/examples/benchmark_channel_asc.rs
+++ b/crates/test-channels-asc/examples/benchmark_channel_asc.rs
@@ -2,7 +2,8 @@ use std::time::Instant;
 
 // Simple single-threaded stress test: hammers a single instrumented channel in
 // a tight loop with no contention, so the measured time reflects per-send/recv
-// instrumentation overhead. Compare `--features hotpath` against a plain run.
+// instrumentation overhead of the forwarder (`proxy = true`) path. Compare
+// `--features hotpath` against a plain run.
 fn main() {
     smol::block_on(async {
         let _guard = hotpath::HotpathGuardBuilder::new("main")
@@ -10,7 +11,11 @@ fn main() {
             .build();
 
         let runs = bench_runs();
-        let (tx, rx) = hotpath::channel!(async_channel::unbounded::<u64>(), label = "counter");
+        let (tx, rx) = hotpath::channel!(
+            async_channel::unbounded::<u64>(),
+            proxy = true,
+            label = "counter"
+        );
 
         let start = Instant::now();
         for i in 0..runs {

--- a/crates/test-channels-asc/examples/wrap_asc.rs
+++ b/crates/test-channels-asc/examples/wrap_asc.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` async-channel instrumentation: the report shows the exact
+// Demonstrates async-channel instrumentation: the report shows the exact
 // queue depth (50 messages parked in the channel) because the instrumented endpoints
 // sample the real channel length instead of routing through a forwarder task.
 //
@@ -13,12 +13,8 @@ fn main() {
             .sections(vec![hotpath::Section::Channels])
             .build();
 
-        // wrap = true returns hotpath::wrap::async_channel::{Sender, Receiver}.
-        let (tx, rx) = hotpath::channel!(
-            async_channel::bounded::<i32>(100),
-            wrap = true,
-            label = "wrap-queue"
-        );
+        // Returns hotpath::wrap::async_channel::{Sender, Receiver}.
+        let (tx, rx) = hotpath::channel!(async_channel::bounded::<i32>(100), label = "wrap-queue");
 
         // Park 50 messages in the channel without receiving any.
         for i in 0..50 {

--- a/crates/test-channels-asc/examples/wrap_closed_asc.rs
+++ b/crates/test-channels-asc/examples/wrap_closed_asc.rs
@@ -9,11 +9,7 @@ fn main() {
             .sections(vec![hotpath::Section::Channels])
             .build();
 
-        let (tx, rx) = hotpath::channel!(
-            async_channel::bounded::<i32>(10),
-            wrap = true,
-            label = "recv-dropped"
-        );
+        let (tx, rx) = hotpath::channel!(async_channel::bounded::<i32>(10), label = "recv-dropped");
 
         tx.send(1).await.expect("Failed to send");
 

--- a/crates/test-channels-asc/examples/wrap_latency_asc.rs
+++ b/crates/test-channels-asc/examples/wrap_latency_asc.rs
@@ -14,16 +14,16 @@ fn main() {
             .percentiles(&[50.0, 95.0])
             .build();
 
-        // wrap = true: exact send->receive latency histogram.
-        let (wtx, wrx) = hotpath::channel!(
-            async_channel::unbounded::<i32>(),
-            wrap = true,
-            label = "wrap-latency"
-        );
+        // Exact send->receive latency histogram.
+        let (wtx, wrx) =
+            hotpath::channel!(async_channel::unbounded::<i32>(), label = "wrap-latency");
 
-        // proxy (no wrap): no latency histogram is recorded.
-        let (ptx, prx) =
-            hotpath::channel!(async_channel::unbounded::<i32>(), label = "proxy-latency");
+        // proxy (forwarder): no latency histogram is recorded.
+        let (ptx, prx) = hotpath::channel!(
+            async_channel::unbounded::<i32>(),
+            proxy = true,
+            label = "proxy-latency"
+        );
 
         for i in 0..10 {
             wtx.send(i).await.expect("Failed to send");

--- a/crates/test-channels-asc/examples/wrap_recv_clone_closed_asc.rs
+++ b/crates/test-channels-asc/examples/wrap_recv_clone_closed_asc.rs
@@ -13,7 +13,6 @@ fn main() {
 
         let (tx, rx) = hotpath::channel!(
             async_channel::bounded::<i32>(10),
-            wrap = true,
             label = "recv-clone-dropped"
         );
 

--- a/crates/test-channels-crossbeam/examples/benchmark_channel_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/benchmark_channel_crossbeam.rs
@@ -2,14 +2,19 @@ use std::time::Instant;
 
 // Simple single-threaded stress test: hammers a single instrumented channel in
 // a tight loop with no contention, so the measured time reflects per-send/recv
-// instrumentation overhead. Compare `--features hotpath` against a plain run.
+// instrumentation overhead of the forwarder (`proxy = true`) path. Compare
+// `--features hotpath` against a plain run.
 fn main() {
     let _guard = hotpath::HotpathGuardBuilder::new("main")
         .sections(vec![hotpath::Section::Channels])
         .build();
 
     let runs = bench_runs();
-    let (tx, rx) = hotpath::channel!(crossbeam_channel::unbounded::<u64>(), label = "counter");
+    let (tx, rx) = hotpath::channel!(
+        crossbeam_channel::unbounded::<u64>(),
+        proxy = true,
+        label = "counter"
+    );
 
     let start = Instant::now();
     for i in 0..runs {

--- a/crates/test-channels-crossbeam/examples/benchmark_channel_wrap_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/benchmark_channel_wrap_crossbeam.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-// Same single-threaded stress test as `benchmark_channel_crossbeam`, but with `wrap = true`.
+// Same single-threaded stress test as `benchmark_channel_crossbeam`.
 // Wrap mode instruments the channel endpoints directly instead of relaying every message
 // through a forwarder thread and a second channel, so this measures the per-send/recv
 // overhead of the wrapped endpoints. Compare against `benchmark_channel_crossbeam` to see
@@ -11,11 +11,7 @@ fn main() {
         .build();
 
     let runs = bench_runs();
-    let (tx, rx) = hotpath::channel!(
-        crossbeam_channel::unbounded::<u64>(),
-        wrap = true,
-        label = "counter"
-    );
+    let (tx, rx) = hotpath::channel!(crossbeam_channel::unbounded::<u64>(), label = "counter");
 
     let start = Instant::now();
     for i in 0..runs {

--- a/crates/test-channels-crossbeam/examples/crossbeam_wrap_little.rs
+++ b/crates/test-channels-crossbeam/examples/crossbeam_wrap_little.rs
@@ -148,14 +148,9 @@ fn main() {
 
     // Distinct `channel!` call sites so each keeps its own label (a shared source
     // line would get a `-N` disambiguation suffix).
-    let (a_tx, a_rx) = hotpath::channel!(
-        crossbeam_channel::unbounded::<u64>(),
-        wrap = true,
-        label = "keeps-up"
-    );
+    let (a_tx, a_rx) = hotpath::channel!(crossbeam_channel::unbounded::<u64>(), label = "keeps-up");
     let (b_tx, b_rx) = hotpath::channel!(
         crossbeam_channel::unbounded::<u64>(),
-        wrap = true,
         label = "falls-behind"
     );
 

--- a/crates/test-channels-crossbeam/examples/wrap_closed_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/wrap_closed_crossbeam.rs
@@ -10,7 +10,6 @@ fn main() {
 
     let (tx, rx) = hotpath::channel!(
         crossbeam_channel::bounded::<i32>(10),
-        wrap = true,
         label = "recv-dropped"
     );
 

--- a/crates/test-channels-crossbeam/examples/wrap_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/wrap_crossbeam.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` crossbeam instrumentation: the report shows the
+// Demonstrates crossbeam channel instrumentation: the report shows the
 // exact queue depth (50 messages parked in the channel) because the instrumented
 // endpoints sample the real channel length instead of routing through a forwarder.
 //
@@ -12,12 +12,8 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::crossbeam_channel::{Sender, Receiver}.
-    let (tx, rx) = hotpath::channel!(
-        crossbeam_channel::bounded::<i32>(100),
-        wrap = true,
-        label = "wrap-queue"
-    );
+    // Returns hotpath::wrap::crossbeam_channel::{Sender, Receiver}.
+    let (tx, rx) = hotpath::channel!(crossbeam_channel::bounded::<i32>(100), label = "wrap-queue");
 
     // Park 50 messages in the channel without receiving any.
     for i in 0..50 {

--- a/crates/test-channels-crossbeam/examples/wrap_latency_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/wrap_latency_crossbeam.rs
@@ -14,16 +14,16 @@ fn main() {
         .percentiles(&[50.0, 95.0])
         .build();
 
-    // wrap = true: exact send->receive latency histogram.
+    // Exact send->receive latency histogram.
     let (wtx, wrx) = hotpath::channel!(
         crossbeam_channel::unbounded::<i32>(),
-        wrap = true,
         label = "wrap-latency"
     );
 
-    // proxy (no wrap): no latency histogram is recorded.
+    // proxy (forwarder): no latency histogram is recorded.
     let (ptx, prx) = hotpath::channel!(
         crossbeam_channel::unbounded::<i32>(),
+        proxy = true,
         label = "proxy-latency"
     );
 

--- a/crates/test-channels-crossbeam/examples/wrap_recv_clone_closed_crossbeam.rs
+++ b/crates/test-channels-crossbeam/examples/wrap_recv_clone_closed_crossbeam.rs
@@ -13,7 +13,6 @@ fn main() {
 
     let (tx, rx) = hotpath::channel!(
         crossbeam_channel::bounded::<i32>(10),
-        wrap = true,
         label = "recv-clone-dropped"
     );
 

--- a/crates/test-channels-flume/examples/benchmark_channel_flume.rs
+++ b/crates/test-channels-flume/examples/benchmark_channel_flume.rs
@@ -2,7 +2,8 @@ use std::time::Instant;
 
 // Simple single-threaded stress test: hammers a single instrumented channel in
 // a tight loop with no contention, so the measured time reflects per-send/recv
-// instrumentation overhead. Compare `--features hotpath` against a plain run.
+// instrumentation overhead of the forwarder (`proxy = true`) path. Compare
+// `--features hotpath` against a plain run.
 fn main() {
     smol::block_on(async {
         let _guard = hotpath::HotpathGuardBuilder::new("main")
@@ -10,7 +11,8 @@ fn main() {
             .build();
 
         let runs = bench_runs();
-        let (tx, rx) = hotpath::channel!(flume::unbounded::<u64>(), label = "counter");
+        let (tx, rx) =
+            hotpath::channel!(flume::unbounded::<u64>(), proxy = true, label = "counter");
 
         let start = Instant::now();
         for i in 0..runs {

--- a/crates/test-channels-flume/examples/benchmark_channel_wrap_flume.rs
+++ b/crates/test-channels-flume/examples/benchmark_channel_wrap_flume.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-// Same single-threaded stress test as `benchmark_channel_flume`, but with `wrap = true`.
+// Same single-threaded stress test as `benchmark_channel_flume`.
 // Wrap mode instruments the channel endpoints directly instead of relaying every message
 // through a forwarder task and a second channel, so this measures the per-send/recv
 // overhead of the wrapped endpoints. Compare against `benchmark_channel_flume` to see
@@ -11,7 +11,7 @@ fn main() {
         .build();
 
     let runs = bench_runs();
-    let (tx, rx) = hotpath::channel!(flume::unbounded::<u64>(), wrap = true, label = "counter");
+    let (tx, rx) = hotpath::channel!(flume::unbounded::<u64>(), label = "counter");
 
     let start = Instant::now();
     for i in 0..runs {

--- a/crates/test-channels-flume/examples/wrap_closed_flume.rs
+++ b/crates/test-channels-flume/examples/wrap_closed_flume.rs
@@ -8,11 +8,7 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    let (tx, rx) = hotpath::channel!(
-        flume::bounded::<i32>(10),
-        wrap = true,
-        label = "recv-dropped"
-    );
+    let (tx, rx) = hotpath::channel!(flume::bounded::<i32>(10), label = "recv-dropped");
 
     tx.send(1).expect("Failed to send");
 

--- a/crates/test-channels-flume/examples/wrap_flume.rs
+++ b/crates/test-channels-flume/examples/wrap_flume.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` flume instrumentation: the report shows the exact
+// Demonstrates flume channel instrumentation: the report shows the exact
 // queue depth (50 messages parked in the channel) because the instrumented endpoints
 // sample the real channel length instead of routing through a forwarder task.
 //
@@ -12,12 +12,8 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::flume::{Sender, Receiver}.
-    let (tx, rx) = hotpath::channel!(
-        flume::bounded::<i32>(100),
-        wrap = true,
-        label = "wrap-queue"
-    );
+    // Returns hotpath::wrap::flume::{Sender, Receiver}.
+    let (tx, rx) = hotpath::channel!(flume::bounded::<i32>(100), label = "wrap-queue");
 
     // Park 50 messages in the channel without receiving any.
     for i in 0..50 {

--- a/crates/test-channels-flume/examples/wrap_latency_flume.rs
+++ b/crates/test-channels-flume/examples/wrap_latency_flume.rs
@@ -14,15 +14,15 @@ fn main() {
         .percentiles(&[50.0, 95.0])
         .build();
 
-    // wrap = true: exact send->receive latency histogram.
-    let (wtx, wrx) = hotpath::channel!(
-        flume::unbounded::<i32>(),
-        wrap = true,
-        label = "wrap-latency"
-    );
+    // Exact send->receive latency histogram.
+    let (wtx, wrx) = hotpath::channel!(flume::unbounded::<i32>(), label = "wrap-latency");
 
-    // proxy (no wrap): no latency histogram is recorded.
-    let (ptx, prx) = hotpath::channel!(flume::unbounded::<i32>(), label = "proxy-latency");
+    // proxy (forwarder): no latency histogram is recorded.
+    let (ptx, prx) = hotpath::channel!(
+        flume::unbounded::<i32>(),
+        proxy = true,
+        label = "proxy-latency"
+    );
 
     for i in 0..10 {
         wtx.send(i).expect("Failed to send");

--- a/crates/test-channels-flume/examples/wrap_recv_clone_closed_flume.rs
+++ b/crates/test-channels-flume/examples/wrap_recv_clone_closed_flume.rs
@@ -11,11 +11,7 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    let (tx, rx) = hotpath::channel!(
-        flume::bounded::<i32>(10),
-        wrap = true,
-        label = "recv-clone-dropped"
-    );
+    let (tx, rx) = hotpath::channel!(flume::bounded::<i32>(10), label = "recv-clone-dropped");
 
     let tx2 = tx.clone();
     let rx2 = rx.clone();

--- a/crates/test-channels-ftc/examples/basic_ftc.rs
+++ b/crates/test-channels-ftc/examples/basic_ftc.rs
@@ -20,17 +20,20 @@ fn main() {
 
         let (txa, mut _rxa) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<i32>(),
+            proxy = true,
             label = _actor1.name
         );
 
         let (mut txb, mut rxb) = hotpath::channel!(
             futures_channel::mpsc::channel::<i32>(10),
+            proxy = true,
             capacity = 10,
             label = "bounded-channel"
         );
 
         let (txc, rxc) = hotpath::channel!(
             futures_channel::oneshot::channel::<String>(),
+            proxy = true,
             label = "oneshot-labeled"
         );
 

--- a/crates/test-channels-ftc/examples/basic_json_ftc.rs
+++ b/crates/test-channels-ftc/examples/basic_json_ftc.rs
@@ -12,17 +12,20 @@ fn main() {
 
         let (txa, mut _rxa) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<i32>(),
+            proxy = true,
             label = "unbounded"
         );
 
         let (mut txb, mut rxb) = hotpath::channel!(
             futures_channel::mpsc::channel::<i32>(10),
+            proxy = true,
             label = "bounded",
             capacity = 10
         );
 
         let (txc, rxc) = hotpath::channel!(
             futures_channel::oneshot::channel::<String>(),
+            proxy = true,
             label = "oneshot"
         );
 

--- a/crates/test-channels-ftc/examples/benchmark_channel_ftc.rs
+++ b/crates/test-channels-ftc/examples/benchmark_channel_ftc.rs
@@ -11,8 +11,11 @@ fn main() {
             .build();
 
         let runs = bench_runs();
-        let (tx, mut rx) =
-            hotpath::channel!(futures_channel::mpsc::unbounded::<u64>(), label = "counter");
+        let (tx, mut rx) = hotpath::channel!(
+            futures_channel::mpsc::unbounded::<u64>(),
+            proxy = true,
+            label = "counter"
+        );
 
         let start = Instant::now();
         for i in 0..runs {

--- a/crates/test-channels-ftc/examples/closed_ftc.rs
+++ b/crates/test-channels-ftc/examples/closed_ftc.rs
@@ -11,17 +11,20 @@ fn main() {
 
         let (txa, mut rxa) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<i32>(),
+            proxy = true,
             label = "unbounded"
         );
 
         let (mut txb, mut rxb) = hotpath::channel!(
             futures_channel::mpsc::channel::<i32>(10),
+            proxy = true,
             label = "bounded",
             capacity = 10
         );
 
         let (txc, rxc) = hotpath::channel!(
             futures_channel::oneshot::channel::<String>(),
+            proxy = true,
             label = "oneshot"
         );
 

--- a/crates/test-channels-ftc/examples/console_feed_ftc.rs
+++ b/crates/test-channels-ftc/examples/console_feed_ftc.rs
@@ -16,6 +16,7 @@ fn main() {
         // Channel 1: Fast data stream - unbounded, rapid messages
         let (tx_fast, mut rx_fast) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<String>(),
+            proxy = true,
             label = "fast-stream",
             log = true
         );
@@ -23,6 +24,7 @@ fn main() {
         // Channel 2: Slow consumer - bounded(5), will back up!
         let (mut tx_slow, mut rx_slow) = hotpath::channel!(
             futures_channel::mpsc::channel::<String>(5),
+            proxy = true,
             label = "slow-consumer",
             capacity = 5,
             log = true
@@ -31,6 +33,7 @@ fn main() {
         // Channel 3: Burst traffic - bounded(10), bursts every 3 seconds
         let (mut tx_burst, mut rx_burst) = hotpath::channel!(
             futures_channel::mpsc::channel::<u64>(10),
+            proxy = true,
             label = "burst-traffic",
             capacity = 10,
             log = true
@@ -39,6 +42,7 @@ fn main() {
         // Channel 4: Gradual flow - bounded(20), increasing rate
         let (mut tx_gradual, mut rx_gradual) = hotpath::channel!(
             futures_channel::mpsc::channel::<f64>(20),
+            proxy = true,
             label = "gradual-flow",
             capacity = 20,
             log = true
@@ -47,6 +51,7 @@ fn main() {
         // Channel 5: Dropped early - unbounded, producer dies at 10s
         let (tx_drop_early, mut rx_drop_early) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<bool>(),
+            proxy = true,
             label = "dropped-early",
             log = true
         );
@@ -54,6 +59,7 @@ fn main() {
         // Channel 6: Consumer dies - bounded(8), consumer stops at 15s
         let (mut tx_consumer_dies, mut rx_consumer_dies) = hotpath::channel!(
             futures_channel::mpsc::channel::<Vec<u8>>(8),
+            proxy = true,
             label = "consumer-dies",
             capacity = 8,
             log = true
@@ -62,6 +68,7 @@ fn main() {
         // Channel 7: Steady stream - unbounded, consistent 500ms rate
         let (tx_steady, mut rx_steady) = hotpath::channel!(
             futures_channel::mpsc::unbounded::<&str>(),
+            proxy = true,
             label = "steady-stream",
             log = true
         );
@@ -69,6 +76,7 @@ fn main() {
         // Channel 8: Oneshot early - fires at 5 seconds
         let (tx_oneshot_early, rx_oneshot_early) = hotpath::channel!(
             futures_channel::oneshot::channel::<String>(),
+            proxy = true,
             label = "oneshot-early",
             log = true
         );
@@ -76,6 +84,7 @@ fn main() {
         // Channel 9: Oneshot mid - fires at 15 seconds
         let (tx_oneshot_mid, rx_oneshot_mid) = hotpath::channel!(
             futures_channel::oneshot::channel::<u32>(),
+            proxy = true,
             label = "oneshot-mid",
             log = true
         );
@@ -83,14 +92,18 @@ fn main() {
         // Channel 10: Oneshot late - fires at 25 seconds
         let (tx_oneshot_late, rx_oneshot_late) = hotpath::channel!(
             futures_channel::oneshot::channel::<i64>(),
+            proxy = true,
             label = "oneshot-late",
             log = true
         );
 
         println!("Creating 3 bounded iter channels...");
         for i in 0..3 {
-            let (mut tx, mut rx) =
-                hotpath::channel!(futures_channel::mpsc::channel::<u32>(5), capacity = 5);
+            let (mut tx, mut rx) = hotpath::channel!(
+                futures_channel::mpsc::channel::<u32>(5),
+                proxy = true,
+                capacity = 5
+            );
 
             smol::spawn(async move {
                 for j in 0..5 {

--- a/crates/test-channels-ftc/examples/iter_ftc.rs
+++ b/crates/test-channels-ftc/examples/iter_ftc.rs
@@ -23,6 +23,7 @@ fn main() {
         for i in 0..3 {
             let (tx, mut rx) = hotpath::channel!(
                 futures_channel::mpsc::unbounded::<i32>(),
+                proxy = true,
                 label = _actor1.name.clone()
             );
 
@@ -39,6 +40,7 @@ fn main() {
         for i in 0..3 {
             let (mut tx, mut rx) = hotpath::channel!(
                 futures_channel::mpsc::channel::<i32>(10),
+                proxy = true,
                 capacity = 10,
                 label = "bounded"
             );
@@ -54,7 +56,8 @@ fn main() {
 
         println!("\nCreating 3 oneshot channels:");
         for i in 0..3 {
-            let (tx, rx) = hotpath::channel!(futures_channel::oneshot::channel::<String>());
+            let (tx, rx) =
+                hotpath::channel!(futures_channel::oneshot::channel::<String>(), proxy = true);
 
             println!("  - Created oneshot channel {}", i);
 

--- a/crates/test-channels-ftc/examples/oneshot_closed_ftc.rs
+++ b/crates/test-channels-ftc/examples/oneshot_closed_ftc.rs
@@ -10,6 +10,7 @@ fn main() {
 
         let (tx, rx) = hotpath::channel!(
             futures_channel::oneshot::channel::<String>(),
+            proxy = true,
             label = "oneshot-closed"
         );
 

--- a/crates/test-channels-ftc/examples/slow_consumer_ftc.rs
+++ b/crates/test-channels-ftc/examples/slow_consumer_ftc.rs
@@ -17,6 +17,7 @@ fn main() {
 
         let (mut tx, mut rx) = hotpath::channel!(
             futures_channel::mpsc::channel::<i32>(10),
+            proxy = true,
             capacity = 10,
             label = "slow-consumer",
             log = true

--- a/crates/test-channels-std/examples/benchmark_channel_std.rs
+++ b/crates/test-channels-std/examples/benchmark_channel_std.rs
@@ -2,14 +2,19 @@ use std::time::Instant;
 
 // Simple single-threaded stress test: hammers a single instrumented channel in
 // a tight loop with no contention, so the measured time reflects per-send/recv
-// instrumentation overhead. Compare `--features hotpath` against a plain run.
+// instrumentation overhead of the forwarder (`proxy = true`) path. Compare
+// `--features hotpath` against a plain run.
 fn main() {
     let _guard = hotpath::HotpathGuardBuilder::new("main")
         .sections(vec![hotpath::Section::Channels])
         .build();
 
     let runs = bench_runs();
-    let (tx, rx) = hotpath::channel!(std::sync::mpsc::channel::<u64>(), label = "counter");
+    let (tx, rx) = hotpath::channel!(
+        std::sync::mpsc::channel::<u64>(),
+        proxy = true,
+        label = "counter"
+    );
 
     let start = Instant::now();
     for i in 0..runs {

--- a/crates/test-channels-std/examples/benchmark_channel_wrap_std.rs
+++ b/crates/test-channels-std/examples/benchmark_channel_wrap_std.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-// Same single-threaded stress test as `benchmark_channel_std`, but with `wrap = true`.
+// Same single-threaded stress test as `benchmark_channel_std`.
 // Wrap mode instruments the channel endpoints directly instead of relaying every message
 // through a forwarder thread and a second channel, so this measures the per-send/recv
 // overhead of the wrapped endpoints. Compare against `benchmark_channel_std` to see the
@@ -11,11 +11,7 @@ fn main() {
         .build();
 
     let runs = bench_runs();
-    let (tx, rx) = hotpath::channel!(
-        std::sync::mpsc::channel::<u64>(),
-        wrap = true,
-        label = "counter"
-    );
+    let (tx, rx) = hotpath::channel!(std::sync::mpsc::channel::<u64>(), label = "counter");
 
     let start = Instant::now();
     for i in 0..runs {

--- a/crates/test-channels-std/examples/wrap_arg_orders_std.rs
+++ b/crates/test-channels-std/examples/wrap_arg_orders_std.rs
@@ -1,6 +1,6 @@
-// Exercises bounded-std wrap channels with `capacity` in every argument position,
-// including the orders that previously failed to compile (label/log/capacity before or
-// after `wrap = true`). Each channel gets a distinct label so the report lists them all.
+// Exercises bounded-std channels with `capacity` in every argument
+// position, combined with `label` and `log` in every order. Each channel gets a distinct
+// label so the report lists them all.
 //
 // cargo run -p test-channels-std --example wrap_arg_orders_std --features hotpath
 use std::sync::mpsc;
@@ -12,49 +12,18 @@ fn main() {
         .build();
 
     let chans = [
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            wrap = true,
-            capacity = 4,
-            label = "a"
-        ),
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            capacity = 4,
-            wrap = true,
-            label = "b"
-        ),
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            label = "c",
-            wrap = true,
-            capacity = 4
-        ),
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            label = "d",
-            capacity = 4,
-            wrap = true
-        ),
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            capacity = 4,
-            label = "e",
-            wrap = true
-        ),
-        hotpath::channel!(
-            mpsc::sync_channel::<i32>(4),
-            wrap = true,
-            label = "f",
-            capacity = 4
-        ),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), capacity = 4, label = "a"),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), label = "b", capacity = 4),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), capacity = 4, label = "c"),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), label = "d", capacity = 4),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), capacity = 4, label = "e"),
+        hotpath::channel!(mpsc::sync_channel::<i32>(4), label = "f", capacity = 4),
     ];
 
-    // log = true combined with capacity, both orders.
+    // log = true combined with capacity and label, both orders.
     let (gtx, grx) = hotpath::channel!(
         mpsc::sync_channel::<i32>(4),
         label = "g",
-        wrap = true,
         capacity = 4,
         log = true
     );
@@ -62,7 +31,6 @@ fn main() {
         mpsc::sync_channel::<i32>(4),
         log = true,
         capacity = 4,
-        wrap = true,
         label = "h"
     );
 

--- a/crates/test-channels-std/examples/wrap_closed_std.rs
+++ b/crates/test-channels-std/examples/wrap_closed_std.rs
@@ -11,7 +11,7 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    let (tx, rx) = hotpath::channel!(mpsc::channel::<i32>(), wrap = true, label = "recv-dropped");
+    let (tx, rx) = hotpath::channel!(mpsc::channel::<i32>(), label = "recv-dropped");
 
     tx.send(1).expect("Failed to send");
 

--- a/crates/test-channels-std/examples/wrap_concurrent_std.rs
+++ b/crates/test-channels-std/examples/wrap_concurrent_std.rs
@@ -15,11 +15,7 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    let (tx, rx) = hotpath::channel!(
-        mpsc::channel::<u64>(),
-        wrap = true,
-        label = "wrap-concurrent"
-    );
+    let (tx, rx) = hotpath::channel!(mpsc::channel::<u64>(), label = "wrap-concurrent");
 
     let producer = thread::spawn(move || {
         for i in 0..N {

--- a/crates/test-channels-std/examples/wrap_dropin_std.rs
+++ b/crates/test-channels-std/examples/wrap_dropin_std.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc;
 
 fn main() {
     let (tx, rx): (SyncSender<i32>, Receiver<i32>) =
-        hotpath::channel!(mpsc::sync_channel::<i32>(8), wrap = true, capacity = 8);
+        hotpath::channel!(mpsc::sync_channel::<i32>(8), capacity = 8);
 
     tx.send(1).expect("send");
     let got = rx.recv().expect("recv");

--- a/crates/test-channels-std/examples/wrap_std.rs
+++ b/crates/test-channels-std/examples/wrap_std.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` std::sync::mpsc instrumentation: the report shows the
+// Demonstrates std::sync::mpsc channel instrumentation: the report shows the
 // exact queue depth (50 messages parked in the channel) because the instrumented
 // endpoints track queue length with a self-maintained counter instead of routing
 // through a forwarder thread.
@@ -18,10 +18,9 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::std::sync::mpsc::{SyncSender, Receiver}.
+    // Returns hotpath::wrap::std::sync::mpsc::{SyncSender, Receiver}.
     let (tx, rx) = hotpath::channel!(
         mpsc::sync_channel::<i32>(100),
-        wrap = true,
         capacity = 100,
         label = "wrap-queue"
     );

--- a/crates/test-channels-std/examples/wrap_unbounded_std.rs
+++ b/crates/test-channels-std/examples/wrap_unbounded_std.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` std::sync::mpsc instrumentation on an unbounded channel.
+// Demonstrates std::sync::mpsc channel instrumentation on an unbounded channel.
 // Sends N messages, drains them all, and the report reflects exact sent/received
 // counts with the self-tracked queue draining back to zero.
 //
@@ -15,12 +15,8 @@ fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::std::sync::mpsc::{Sender, Receiver}.
-    let (tx, rx) = hotpath::channel!(
-        mpsc::channel::<i32>(),
-        wrap = true,
-        label = "wrap-unbounded"
-    );
+    // Returns hotpath::wrap::std::sync::mpsc::{Sender, Receiver}.
+    let (tx, rx) = hotpath::channel!(mpsc::channel::<i32>(), label = "wrap-unbounded");
 
     for i in 0..200 {
         tx.send(i).expect("Failed to send");

--- a/crates/test-channels-tokio/examples/basic_json_tokio.rs
+++ b/crates/test-channels-tokio/examples/basic_json_tokio.rs
@@ -12,6 +12,7 @@ async fn main() {
 
     let (txc, rxc) = hotpath::channel!(
         tokio::sync::oneshot::channel::<String>(),
+        proxy = true,
         label = "hello-there"
     );
 

--- a/crates/test-channels-tokio/examples/basic_tokio.rs
+++ b/crates/test-channels-tokio/examples/basic_tokio.rs
@@ -27,6 +27,7 @@ async fn main() {
 
     let (txc, rxc) = hotpath::channel!(
         tokio::sync::oneshot::channel::<String>(),
+        proxy = true,
         label = "hello-there"
     );
 

--- a/crates/test-channels-tokio/examples/benchmark_channel_tokio.rs
+++ b/crates/test-channels-tokio/examples/benchmark_channel_tokio.rs
@@ -2,7 +2,8 @@ use std::time::Instant;
 
 // Simple single-threaded stress test: hammers a single instrumented channel in
 // a tight loop with no contention, so the measured time reflects per-send/recv
-// instrumentation overhead. Compare `--features hotpath` against a plain run.
+// instrumentation overhead of the forwarder (`proxy = true`) path. Compare
+// `--features hotpath` against a plain run.
 #[tokio::main]
 async fn main() {
     let _guard = hotpath::HotpathGuardBuilder::new("main")
@@ -12,6 +13,7 @@ async fn main() {
     let runs = bench_runs();
     let (tx, mut rx) = hotpath::channel!(
         tokio::sync::mpsc::unbounded_channel::<u64>(),
+        proxy = true,
         label = "counter"
     );
 

--- a/crates/test-channels-tokio/examples/benchmark_channel_wrap_tokio.rs
+++ b/crates/test-channels-tokio/examples/benchmark_channel_wrap_tokio.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-// Same single-threaded stress test as `benchmark_channel_tokio`, but with `wrap = true`.
+// Same single-threaded stress test as `benchmark_channel_tokio`.
 // Wrap mode instruments the channel endpoints directly instead of relaying every message
 // through a forwarder task and a second channel, so this measures the per-send/recv
 // overhead of the wrapped endpoints. Compare against `benchmark_channel_tokio` to see the
@@ -14,7 +14,6 @@ async fn main() {
     let runs = bench_runs();
     let (tx, mut rx) = hotpath::channel!(
         tokio::sync::mpsc::unbounded_channel::<u64>(),
-        wrap = true,
         label = "counter"
     );
 

--- a/crates/test-channels-tokio/examples/closed_tokio.rs
+++ b/crates/test-channels-tokio/examples/closed_tokio.rs
@@ -17,6 +17,7 @@ async fn main() {
 
     let (txc, rxc) = hotpath::channel!(
         tokio::sync::oneshot::channel::<String>(),
+        proxy = true,
         label = "oneshot-channel"
     );
 

--- a/crates/test-channels-tokio/examples/console_feed_tokio.rs
+++ b/crates/test-channels-tokio/examples/console_feed_tokio.rs
@@ -175,16 +175,23 @@ async fn main() {
         hotpath::channel!(tokio::sync::mpsc::unbounded_channel::<&str>(), log = true);
 
     // Channel 8: Oneshot early - fires at 5 seconds
-    let (tx_oneshot_early, rx_oneshot_early) =
-        hotpath::channel!(tokio::sync::oneshot::channel::<String>(), log = true);
+    let (tx_oneshot_early, rx_oneshot_early) = hotpath::channel!(
+        tokio::sync::oneshot::channel::<String>(),
+        proxy = true,
+        log = true
+    );
 
     // Channel 9: Oneshot mid - fires at 15 seconds
-    let (tx_oneshot_mid, rx_oneshot_mid) =
-        hotpath::channel!(tokio::sync::oneshot::channel::<u32>(), log = true);
+    let (tx_oneshot_mid, rx_oneshot_mid) = hotpath::channel!(
+        tokio::sync::oneshot::channel::<u32>(),
+        proxy = true,
+        log = true
+    );
 
     // Channel 10: Oneshot late - fires at 25 seconds
     let (tx_oneshot_late, rx_oneshot_late) = hotpath::channel!(
         tokio::sync::oneshot::channel::<i64>(),
+        proxy = true,
         label = "oneshot-late",
         log = true
     );

--- a/crates/test-channels-tokio/examples/iter_tokio.rs
+++ b/crates/test-channels-tokio/examples/iter_tokio.rs
@@ -45,7 +45,7 @@ async fn main() {
 
     println!("\nCreating 3 oneshot channels:");
     for i in 0..3 {
-        let (tx, rx) = hotpath::channel!(tokio::sync::oneshot::channel::<String>());
+        let (tx, rx) = hotpath::channel!(tokio::sync::oneshot::channel::<String>(), proxy = true);
 
         println!("  - Created oneshot channel {}", i);
 

--- a/crates/test-channels-tokio/examples/oneshot_closed_tokio.rs
+++ b/crates/test-channels-tokio/examples/oneshot_closed_tokio.rs
@@ -4,7 +4,7 @@ async fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    let (tx, rx) = hotpath::channel!(tokio::sync::oneshot::channel::<String>());
+    let (tx, rx) = hotpath::channel!(tokio::sync::oneshot::channel::<String>(), proxy = true);
 
     drop(rx);
 

--- a/crates/test-channels-tokio/examples/wrap_closed_tokio.rs
+++ b/crates/test-channels-tokio/examples/wrap_closed_tokio.rs
@@ -12,7 +12,6 @@ async fn main() {
 
     let (tx, rx) = hotpath::channel!(
         tokio::sync::mpsc::unbounded_channel::<i32>(),
-        wrap = true,
         label = "recv-dropped"
     );
 

--- a/crates/test-channels-tokio/examples/wrap_concurrent_tokio.rs
+++ b/crates/test-channels-tokio/examples/wrap_concurrent_tokio.rs
@@ -15,7 +15,6 @@ async fn main() {
 
     let (tx, mut rx) = hotpath::channel!(
         tokio::sync::mpsc::unbounded_channel::<u64>(),
-        wrap = true,
         label = "wrap-concurrent"
     );
 

--- a/crates/test-channels-tokio/examples/wrap_tokio.rs
+++ b/crates/test-channels-tokio/examples/wrap_tokio.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` tokio::sync::mpsc instrumentation: the report shows the
+// Demonstrates tokio::sync::mpsc channel instrumentation: the report shows the
 // exact queue depth (50 messages parked in the channel) because the instrumented
 // endpoints track queue length with a self-maintained counter instead of routing
 // through a forwarder task and a second channel.
@@ -14,12 +14,9 @@ async fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::tokio::sync::mpsc::{Sender, Receiver}.
-    let (tx, mut rx) = hotpath::channel!(
-        tokio::sync::mpsc::channel::<i32>(100),
-        wrap = true,
-        label = "wrap-queue"
-    );
+    // Returns hotpath::wrap::tokio::sync::mpsc::{Sender, Receiver}.
+    let (tx, mut rx) =
+        hotpath::channel!(tokio::sync::mpsc::channel::<i32>(100), label = "wrap-queue");
 
     // Park 50 messages in the channel without receiving any.
     for i in 0..50 {

--- a/crates/test-channels-tokio/examples/wrap_unbounded_tokio.rs
+++ b/crates/test-channels-tokio/examples/wrap_unbounded_tokio.rs
@@ -1,4 +1,4 @@
-// Demonstrates `wrap = true` tokio::sync::mpsc instrumentation on an unbounded channel.
+// Demonstrates tokio::sync::mpsc channel instrumentation on an unbounded channel.
 // Sends N messages, drains them all, and the report reflects exact sent/received counts
 // with the self-tracked queue draining back to zero.
 //
@@ -10,10 +10,9 @@ async fn main() {
         .sections(vec![hotpath::Section::Channels])
         .build();
 
-    // wrap = true returns hotpath::wrap::tokio::sync::mpsc::{UnboundedSender, UnboundedReceiver}.
+    // Returns hotpath::wrap::tokio::sync::mpsc::{UnboundedSender, UnboundedReceiver}.
     let (tx, mut rx) = hotpath::channel!(
         tokio::sync::mpsc::unbounded_channel::<i32>(),
-        wrap = true,
         label = "wrap-unbounded"
     );
 

--- a/crates/test-tokio-async/examples/long_running.rs
+++ b/crates/test-tokio-async/examples/long_running.rs
@@ -400,7 +400,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         label = "fast_metrics",
         log = true
     );
-    let (slow_tx, slow_rx) = hotpath::channel!(mpsc::channel::<String>(50), label = "slow_events");
+    // `proxy = true`: this consumer uses `blocking_recv`, which the wrap receiver
+    // doesn't expose. Forwarder mode keeps the raw tokio `Receiver`.
+    let (slow_tx, slow_rx) = hotpath::channel!(
+        mpsc::channel::<String>(50),
+        proxy = true,
+        label = "slow_events"
+    );
 
     let mut fast_rx = fast_rx;
     let mut slow_rx = slow_rx;

--- a/docs/src/data_flow.md
+++ b/docs/src/data_flow.md
@@ -25,6 +25,13 @@ async fn main() {
 }
 ```
 
+By default `channel!` uses **wrap mode**: it returns instrumented endpoint wrappers
+(`hotpath::wrap::<backend>::{Sender, Receiver}`) that intercept `send`/`recv` inline. This
+gives an exact live queue depth and an exact send-receive latency histogram, with no
+forwarder task or thread. See [Wrapped types](#wrapped-types) for how this affects the
+return type, and [`proxy = true`](#proxy--true-forwarder-mode) for the alternative
+forwarder mode (and the backends that require it).
+
 ### Supported channel libraries
 
 [std::sync](https://doc.rust-lang.org/stable/std/sync/mpsc/index.html) channels are instrumented by default. Enable the matching feature flag for each third-party library.
@@ -88,66 +95,62 @@ Label channels to display them on top of the list. By passing `log = true` TUI w
 
 <img loading="lazy" src="{{#asset-hash images/channels-log.png}}" alt="hotpath-rs TUI showing channel message flow monitoring with send and receive logs">
 
-### Capacity parameter requirement
+### Send-receive latency and queue depth (default)
 
-For `futures::channel::mpsc` bounded channels, you **must** specify the `capacity` parameter because their API doesn't expose the capacity after creation:
-
-```rust
-use futures_channel::mpsc;
-
-// futures bounded channel - MUST specify capacity
-let (tx, rx) = hotpath::channel!(mpsc::channel::<String>(10), capacity = 10);
-```
-
-Tokio, crossbeam, and async-channel channels don't require this parameter because their capacity is accessible from the channel handles.
-
-Bounded `std::sync::mpsc` channels wrapped with `wrap = true` also require `capacity`, and **the value must match the `sync_channel(N)` argument**:
-
-```rust
-use std::sync::mpsc;
-
-// std bounded wrap - capacity MUST equal the sync_channel argument
-let (tx, rx) = hotpath::channel!(mpsc::sync_channel::<String>(100), wrap = true, capacity = 100);
-```
-
-Wrap mode rebuilds the inner channel from `capacity` (std exposes no way to read it back from the endpoints) and discards the channel you constructed. If the two disagree - e.g. `sync_channel(100)` with `capacity = 1` - the profiled build gets a different bound than the unprofiled one (where `channel!` returns your original channel untouched), which can change backpressure or even deadlock only when profiling is enabled. Keep the numbers equal.
-
-### A note on accuracy
-
-`hotpath` instruments channels by using a proxy on the receive side with the capacity of 1. Messages flow directly into your original channel, then through a proxy before reaching the consumer. Sent/received counts are observed at the proxy boundary (between the original channel and the proxy), not at the final consumer. In practice, the observable results closely reflect the real ones - counts will match exactly once messages pass through the proxy. 
-
-Please note that enabling monitoring can subtly affect channel behavior in some cases. For example, using `try_send` may behave slightly differently since the proxy adds 1 slot of extra capacity. Also some wrappers currently do not propagate info about receiver getting dropped.
-
-I'm actively improving the library, so any feedback, issues, bug reports are appreciated.
-
-### Send-receive latency and queue depth (`wrap = true`)
-
-For `crossbeam`, `std`, `tokio` (`mpsc`), `flume`, and `async-channel` channels you can opt into **endpoint wrapping** with `wrap = true`. Instead of inserting a forwarder-proxy, this wraps the `Sender`/`Receiver` directly and stamps each message with its send time, so the report gains an exact **send-receive latency** histogram (`proc_avg` plus the configured percentiles), alongside an exact live queue depth:
+By default `channel!` wraps the `Sender`/`Receiver` endpoints directly and stamps each message with its send time, so the report gains an exact **send-receive latency** histogram (`proc_avg` plus the configured percentiles), alongside an exact live queue depth. No forwarder task or thread is inserted:
 
 ```rust
 let (tx, rx) = hotpath::channel!(
     crossbeam_channel::unbounded::<i32>(),
-    wrap = true,
     label = "jobs"
 );
 
 // tokio mpsc, bounded or unbounded - no `capacity` argument needed
 let (tx, rx) = hotpath::channel!(
     tokio::sync::mpsc::channel::<i32>(100),
-    wrap = true,
     label = "jobs"
 );
 ```
 
-The recorded latency is the full interval from `send()` to `recv()`, including backpressure wait on bounded channels. Because the timestamps are taken inside your own `send`/`recv` calls rather than in a forwarder task or thread, the value is exact - and wrap mode is also lighter than the proxy, since it adds no extra task/thread or hop. Tokio and flume benefit the most: their proxies relay every message through a background task and a second channel, costing a scheduler round-trip per message, whereas wrap mode hits the real channel directly.
+The recorded latency is the full interval from `send()` to `recv()`, including backpressure wait on bounded channels. Because the timestamps are taken inside your own `send`/`recv` calls rather than in a forwarder task or thread, the value is exact - and wrap mode is lighter than the proxy, since it adds no extra task/thread or hop.
 
-Tokio bounded wrap channels do not need a `capacity` argument - the bound is recovered from `Sender::max_capacity()`. flume and async-channel wrap channels (bounded or unbounded) likewise need no `capacity` argument - the bound is recovered from the endpoint.
+Wrap mode is available for `tokio` (`mpsc`), `std`, `crossbeam`, `flume`, and `async-channel`. It is **not** available for `futures_channel` (any kind) or `tokio::sync::oneshot` - those are forwarder-only and require [`proxy = true`](#proxy--true-forwarder-mode).
 
-Latency is reported **only for wrap channels**. A proxy channel stamps its events inside the forwarder thread, in the middle of the pipeline, so it cannot observe the producer-side or consumer-side wait accurately. Prefer `wrap = true` when you care about channel latency.
+### Capacity parameter requirement
+
+Bounded `std::sync::mpsc` channels require an explicit `capacity`, and **the value must match the `sync_channel(N)` argument**:
+
+```rust
+use std::sync::mpsc;
+
+// std bounded - capacity MUST equal the sync_channel argument
+let (tx, rx) = hotpath::channel!(mpsc::sync_channel::<String>(100), capacity = 100);
+```
+
+Wrap mode rebuilds the inner channel from `capacity` (std exposes no way to read it back from the endpoints) and discards the channel you constructed. If the two disagree - e.g. `sync_channel(100)` with `capacity = 1` - the profiled build gets a different bound than the unprofiled one (where `channel!` returns your original channel untouched), which can change backpressure or even deadlock only when profiling is enabled. Keep the numbers equal.
+
+Tokio, crossbeam, flume, and async-channel recover the bound from the endpoint, so they need no `capacity` argument. `futures_channel::mpsc` bounded channels (forwarder-only, see below) also require `capacity = N` because their API doesn't expose it after creation.
+
+### `proxy = true` (forwarder mode)
+
+Passing `proxy = true` selects the original forwarder-based mode. Instead of wrapping the endpoints, `hotpath` keeps your original endpoint types (the return type is unchanged) and spawns a background task/thread that relays every message through a second internal channel, observing sent/received counts at that boundary:
+
+```rust
+// keep the raw endpoint types; instrument via a forwarder
+let (tx, rx) = hotpath::channel!(mpsc::channel::<String>(100), proxy = true);
+
+// required for the forwarder-only backends
+let (tx, rx) = hotpath::channel!(futures_channel::mpsc::channel::<i32>(10), proxy = true, capacity = 10);
+let (tx, rx) = hotpath::channel!(tokio::sync::oneshot::channel::<i32>(), proxy = true);
+```
+
+Use `proxy = true` when you need type-transparent endpoints (see [Wrapped types](#wrapped-types)), or for a backend that has no wrap implementation - `futures_channel` (mpsc and oneshot) and `tokio::sync::oneshot`. Calling `channel!` on one of those without `proxy = true` is a compile error that tells you to add it.
+
+Forwarder mode has two accuracy caveats. The proxy is bounded to capacity 1, so sent/received counts are observed at the proxy boundary rather than at the final consumer, and `try_send` may behave slightly differently since the proxy adds one slot of extra capacity. It also **cannot measure send-receive latency**: it stamps events inside the forwarder, in the middle of the pipeline, so `proc_avg`/percentiles and exact queue depth are omitted. Prefer the default wrap mode when you care about latency or queue depth.
 
 ### Instrumentation overhead
 
-Because wrap mode hits the real channel directly instead of relaying every message through a forwarder task or thread, it is dramatically cheaper for the channel libraries whose proxy needs a background relay. For `tokio` and `flume`, wrap mode cuts per-message instrumentation overhead roughly **5-6x** versus the forwarder proxy, since their proxies cost a scheduler round-trip per message. `async-channel`'s proxy also relays every message through a background async task, so it benefits similarly. `std` also gets a large reduction (its proxy overhead drops by around **4x**). `crossbeam`'s forwarder is already cheap (a tight relay thread, no async scheduling), so the two modes are close there. Whenever a channel type supports `wrap = true`, prefer it over the proxy for both lower overhead and exact latency.
+Because wrap mode hits the real channel directly instead of relaying every message through a forwarder task or thread, the default is dramatically cheaper than `proxy = true` for the libraries whose proxy needs a background relay. For `tokio` and `flume`, wrap mode cuts per-message instrumentation overhead roughly **5-6x** versus the forwarder proxy, since their proxies cost a scheduler round-trip per message. `async-channel`'s proxy also relays every message through a background async task, so it benefits similarly. `std` also gets a large reduction (its proxy overhead drops by around **4x**). `crossbeam`'s forwarder is already cheap (a tight relay thread, no async scheduling), so the two modes are close there.
 
 ## Streams monitoring
 
@@ -222,7 +225,7 @@ Label futures to display them on top of the list. By passing `log = true` TUI wi
 
 ## Wrapped types
 
-`channel!` with `wrap = true` does not return the endpoints you passed in - it returns *instrumented wrappers* around them. The macro expands to a different type than the original:
+By default `channel!` does not return the endpoints you passed in - it returns *instrumented wrappers* around them. The macro expands to a different type than the original:
 
 ```rust
 // before: a plain crossbeam receiver
@@ -230,10 +233,10 @@ let (tx, rx): (crossbeam_channel::Sender<i32>, crossbeam_channel::Receiver<i32>)
     crossbeam_channel::unbounded();
 
 // after: the macro returns hotpath wrappers, not crossbeam_channel::Sender/Receiver
-let (tx, rx) = hotpath::channel!(crossbeam_channel::unbounded::<i32>(), wrap = true);
+let (tx, rx) = hotpath::channel!(crossbeam_channel::unbounded::<i32>());
 ```
 
-At a `let` binding this is invisible - type inference picks up whatever the macro returns. It only matters when you need to *name* the type, for example a struct field or a function signature. There you cannot write `crossbeam_channel::Sender<T>`, because the value is a wrapper, not a `crossbeam_channel::Sender`.
+At a `let` binding this is invisible - type inference picks up whatever the macro returns. It only matters when you need to *name* the type, for example a struct field or a function signature. There you cannot write `crossbeam_channel::Sender<T>`, because the value is a wrapper, not a `crossbeam_channel::Sender`. (If you would rather keep the original endpoint types, use [`proxy = true`](#proxy--true-forwarder-mode), which is type-transparent.)
 
 Use the `hotpath::wrap::` path instead. It mirrors the original module layout, so you prefix the original path with `hotpath::wrap::`:
 

--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ test_all:
     cargo test --features hotpath --test channels_tokio_wrap -- --nocapture --test-threads=1
     cargo test --features hotpath --test channels_ftc -- --nocapture --test-threads=1
     cargo test --features hotpath --test channels_asc -- --nocapture --test-threads=1
+    cargo test --features hotpath --test channels_asc_wrap -- --nocapture --test-threads=1
     cargo test --features hotpath --test channels_std -- --nocapture --test-threads=1
     cargo test --features hotpath --test channels_tokio -- --nocapture --test-threads=1
     cargo test --features hotpath --test channels_flume -- --nocapture --test-threads=1


### PR DESCRIPTION
Change the default channel instrumentation mode to wrap = true. The previous default mode is now available via proxy = true config.