### PR TITLE
fix: Forward all GlobalAlloc methods to custom allocator

### DIFF
--- a/crates/hotpath-meta/src/lib_on/functions/alloc/allocator.rs
+++ b/crates/hotpath-meta/src/lib_on/functions/alloc/allocator.rs
@@ -32,8 +32,9 @@ impl<A: Default> Default for CountingAllocator<A> {
 }
 
 // SAFETY: pure pass-through to the inner allocator `A` - every pointer
-// returned by `alloc` comes from `A::alloc` and every `dealloc` forwards the
-// caller's `ptr`/`layout` unchanged, so `A`'s GlobalAlloc guarantees carry
+// returned by `alloc`/`alloc_zeroed`/`realloc` comes from the corresponding
+// method of `A`, and `dealloc`/`realloc` forward the caller's
+// `ptr`/`layout`/`new_size` unchanged, so `A`'s GlobalAlloc guarantees carry
 // over. The tracking hooks only update thread-local counters and never touch
 // the allocation itself.
 unsafe impl<A> GlobalAlloc for CountingAllocator<A>
@@ -57,5 +58,28 @@ where
         unsafe {
             self.0.dealloc(ptr, layout);
         }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        crate::lib_on::functions::alloc::core::track_alloc(layout.size());
+
+        // SAFETY: caller upholds GlobalAlloc's contract for `layout`; it is
+        // forwarded unchanged.
+        unsafe { self.0.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: caller guarantees `ptr` was allocated by this allocator
+        // with `layout` and that `new_size` is valid per GlobalAlloc's
+        // contract; all three are forwarded unchanged.
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+
+        // Track only on success: a failed realloc leaves the old block alive,
+        // so recording a dealloc for it would over-count frees.
+        if !new_ptr.is_null() {
+            crate::lib_on::functions::alloc::core::track_dealloc(layout.size());
+            crate::lib_on::functions::alloc::core::track_alloc(new_size);
+        }
+        new_ptr
     }
 }

--- a/crates/hotpath/src/lib_on/functions/alloc/allocator.rs
+++ b/crates/hotpath/src/lib_on/functions/alloc/allocator.rs
@@ -32,8 +32,9 @@ impl<A: Default> Default for CountingAllocator<A> {
 }
 
 // SAFETY: pure pass-through to the inner allocator `A` - every pointer
-// returned by `alloc` comes from `A::alloc` and every `dealloc` forwards the
-// caller's `ptr`/`layout` unchanged, so `A`'s GlobalAlloc guarantees carry
+// returned by `alloc`/`alloc_zeroed`/`realloc` comes from the corresponding
+// method of `A`, and `dealloc`/`realloc` forward the caller's
+// `ptr`/`layout`/`new_size` unchanged, so `A`'s GlobalAlloc guarantees carry
 // over. The tracking hooks only update thread-local counters and never touch
 // the allocation itself.
 unsafe impl<A> GlobalAlloc for CountingAllocator<A>
@@ -57,5 +58,28 @@ where
         unsafe {
             self.0.dealloc(ptr, layout);
         }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        crate::lib_on::functions::alloc::core::track_alloc(layout.size());
+
+        // SAFETY: caller upholds GlobalAlloc's contract for `layout`; it is
+        // forwarded unchanged.
+        unsafe { self.0.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: caller guarantees `ptr` was allocated by this allocator
+        // with `layout` and that `new_size` is valid per GlobalAlloc's
+        // contract; all three are forwarded unchanged.
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+
+        // Track only on success: a failed realloc leaves the old block alive,
+        // so recording a dealloc for it would over-count frees.
+        if !new_ptr.is_null() {
+            crate::lib_on::functions::alloc::core::track_dealloc(layout.size());
+            crate::lib_on::functions::alloc::core::track_alloc(new_size);
+        }
+        new_ptr
     }
 }

--- a/crates/hotpath/tests/functions_alloc.rs
+++ b/crates/hotpath/tests/functions_alloc.rs
@@ -532,17 +532,28 @@ pub mod tests {
             .functions_alloc
             .expect("Expected functions_alloc in report");
 
-        let alloc_work = alloc
-            .data
-            .iter()
-            .find(|f| f.name == "custom_allocator::alloc_demo::alloc_work")
-            .expect("Expected custom_allocator::alloc_demo::alloc_work in alloc data");
+        let find = |name: &str| -> &hotpath::json::JsonFunctionEntry {
+            alloc
+                .data
+                .iter()
+                .find(|f| f.name == format!("custom_allocator::alloc_demo::{name}"))
+                .unwrap_or_else(|| panic!("Expected {name} in alloc data"))
+        };
 
-        let total_bytes = hotpath::parse_bytes(&alloc_work.total)
-            .expect("Failed to parse total bytes for custom_allocator::alloc_demo::alloc_work");
+        let alloc_work_bytes = hotpath::parse_bytes(&find("alloc_work").total)
+            .expect("Failed to parse total bytes for alloc_work");
         assert!(
-            total_bytes > 0,
-            "expected alloc_work to report allocated bytes"
+            alloc_work_bytes >= 1024,
+            "expected alloc_work to report the zeroed 1 KB allocation, got {alloc_work_bytes} B"
+        );
+
+        // realloc_work allocates 512 B, then a realloc to >= 4608 B is
+        // tracked as dealloc(512) + alloc(new_size).
+        let realloc_work_bytes = hotpath::parse_bytes(&find("realloc_work").total)
+            .expect("Failed to parse total bytes for realloc_work");
+        assert!(
+            realloc_work_bytes >= 512 + 4608,
+            "expected realloc_work to count both the initial alloc and the realloc'd size, got {realloc_work_bytes} B"
         );
     }
 }

--- a/crates/test-tokio-async/examples/custom_allocator.rs
+++ b/crates/test-tokio-async/examples/custom_allocator.rs
@@ -7,6 +7,8 @@ mod alloc_demo {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+    static ALLOC_ZEROED_CALLS: AtomicU64 = AtomicU64::new(0);
+    static REALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
 
     pub struct TestAllocator;
 
@@ -24,6 +26,19 @@ mod alloc_demo {
             // with `layout`, i.e. by `System`.
             unsafe { System.dealloc(ptr, layout) }
         }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            ALLOC_ZEROED_CALLS.fetch_add(1, Ordering::Relaxed);
+            // SAFETY: caller upholds GlobalAlloc's contract for `layout`.
+            unsafe { System.alloc_zeroed(layout) }
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            REALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+            // SAFETY: caller guarantees `ptr` was allocated by this allocator
+            // with `layout` and a valid `new_size`, i.e. by `System`.
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
     }
 
     #[hotpath::measure]
@@ -32,15 +47,33 @@ mod alloc_demo {
         std::hint::black_box(&buf);
     }
 
+    #[hotpath::measure]
+    fn realloc_work() {
+        let mut buf: Vec<u8> = Vec::with_capacity(512);
+        buf.resize(512, 1);
+        buf.reserve(4096);
+        std::hint::black_box(&buf);
+    }
+
     #[hotpath::main(allocator = TestAllocator)]
     pub fn run() -> Result<(), Box<dyn std::error::Error>> {
-        let before = ALLOC_CALLS.load(Ordering::Relaxed);
+        let alloc_before = ALLOC_CALLS.load(Ordering::Relaxed);
+        let zeroed_before = ALLOC_ZEROED_CALLS.load(Ordering::Relaxed);
         alloc_work();
-        let after = ALLOC_CALLS.load(Ordering::Relaxed);
-
         assert!(
-            after > before,
+            ALLOC_CALLS.load(Ordering::Relaxed) > alloc_before,
             "custom allocator should observe an allocation delta"
+        );
+        assert!(
+            ALLOC_ZEROED_CALLS.load(Ordering::Relaxed) > zeroed_before,
+            "vec![0; n] should hit the custom allocator's native alloc_zeroed"
+        );
+
+        let realloc_before = REALLOC_CALLS.load(Ordering::Relaxed);
+        realloc_work();
+        assert!(
+            REALLOC_CALLS.load(Ordering::Relaxed) > realloc_before,
+            "Vec growth should hit the custom allocator's native realloc"
         );
 
         Ok(())

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -186,3 +186,5 @@ fn main() {
 ```
 
 The path must name a unit struct implementing `GlobalAlloc` (like `MiMalloc` from [mimalloc](https://github.com/purpleprotocol/mimalloc_rust) or `Jemalloc` from [tikv-jemallocator](https://github.com/tikv/jemallocator)). When the `hotpath-alloc` feature is disabled, the parameter is ignored and no allocator is installed, so combine it with your own `#[global_allocator]` behind a feature gate if the program should also use the allocator in normal builds.
+
+All four `GlobalAlloc` methods (`alloc`, `dealloc`, `alloc_zeroed`, `realloc`) forward to the inner allocator's native implementations, so wrapping does not change its zeroed-allocation or reallocation behavior. A successful `realloc` is tracked as a deallocation of the old size plus an allocation of the new size.


### PR DESCRIPTION
closes #479 